### PR TITLE
Fix #55: Issue #55: schema audit: show field/tag IDs and usage locations

### DIFF
--- a/src/commands/schema.ts
+++ b/src/commands/schema.ts
@@ -579,6 +579,15 @@ function printTableReport(report: import('../types/schema-audit').SchemaAuditRep
   for (const finding of findings) {
     const icon = severityIcon[finding.severity] || '•';
     console.log(`${icon} [${finding.severity.toUpperCase()}] ${finding.message}`);
+    if (finding.details.usageLocations && finding.details.usageLocations.length > 0) {
+      for (const loc of finding.details.usageLocations) {
+        const fieldPart = loc.fieldId
+          ? ` → ${loc.fieldName || '?'} (${loc.fieldId})`
+          : '';
+        const typePart = loc.dataType ? `: ${loc.dataType}` : '';
+        console.log(`  → ${loc.tagName}#${loc.tagId}${fieldPart}${typePart}`);
+      }
+    }
     if (finding.details.suggestion) {
       console.log(`  → ${finding.details.suggestion}`);
     }
@@ -610,6 +619,16 @@ function printMarkdownReport(report: import('../types/schema-audit').SchemaAudit
   for (const finding of findings) {
     console.log(`### ${finding.severity.toUpperCase()}: ${finding.message}`);
     console.log(`- Detector: ${finding.detector}`);
+    if (finding.details.usageLocations && finding.details.usageLocations.length > 0) {
+      console.log('- Locations:');
+      for (const loc of finding.details.usageLocations) {
+        const fieldPart = loc.fieldId
+          ? ` → ${loc.fieldName || '?'} (\`${loc.fieldId}\`)`
+          : '';
+        const typePart = loc.dataType ? `: ${loc.dataType}` : '';
+        console.log(`  - \`${loc.tagName}\`#\`${loc.tagId}\`${fieldPart}${typePart}`);
+      }
+    }
     if (finding.details.suggestion) {
       console.log(`- Suggestion: ${finding.details.suggestion}`);
     }

--- a/src/types/schema-audit.ts
+++ b/src/types/schema-audit.ts
@@ -8,6 +8,15 @@
 /** Severity levels for schema findings */
 export type SchemaFindingSeverity = 'error' | 'warning' | 'info';
 
+/** A usage location showing where a tag/field is used */
+export interface UsageLocation {
+  tagId: string;
+  tagName: string;
+  fieldId?: string;
+  fieldName?: string;
+  dataType?: string;
+}
+
 /** A single finding from a schema detector */
 export interface SchemaFinding {
   detector: string;
@@ -22,6 +31,7 @@ export interface SchemaFinding {
     relatedIds?: string[];
     fillRate?: number;
     instanceCount?: number;
+    usageLocations?: UsageLocation[];
   };
   tanaPaste?: string;
 }


### PR DESCRIPTION
Fixes #55

Automated fix for: Issue #55: schema audit: show field/tag IDs and usage locations