### PR TITLE
fix: prevent silent hang in --delta sync when Local API ignores edited.since

### DIFF
--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -158,6 +158,7 @@ async function runDeltaSync(dbPath: string): Promise<DeltaSyncResult> {
   const deltaSyncService = new DeltaSyncService({
     dbPath,
     localApiClient: client,
+    logger,
   });
 
   try {
@@ -706,6 +707,7 @@ export function registerSyncCommands(program: Command): void {
       const deltaSyncService = new DeltaSyncService({
         dbPath: resolvedPaths.dbPath,
         localApiClient: client,
+        logger,
       });
 
       const watchOptions = {

--- a/src/services/delta-sync.ts
+++ b/src/services/delta-sync.ts
@@ -22,6 +22,30 @@ import type {
 const PAGE_SIZE = 100;
 
 /**
+ * Fraction of `sync_metadata.total_nodes` that a single delta is allowed to
+ * exceed before we abort. The failure mode we guard against (Local API
+ * ignoring `edited.since`) returns ~100% of the workspace, so any threshold
+ * below 100% catches it — and the lower the threshold, the less work wasted
+ * before the abort fires. 25% is well below any plausible real delta yet
+ * still allows for months of accumulated edits; a real delta exceeding this
+ * is better served by a full re-sync anyway.
+ */
+const MAX_PAGES_RATIO = 0.25;
+
+/**
+ * Fallback cap if `total_nodes` is unavailable (e.g. malformed metadata).
+ * Conservative — equivalent to a ~400K-node workspace under the ratio.
+ */
+const FALLBACK_MAX_PAGES = 1000;
+
+/**
+ * Log a progress line on page 1 and every Nth page thereafter. Avoids
+ * one-info-line-per-page noise on normal deltas while still proving liveness
+ * on long runs.
+ */
+const PROGRESS_INTERVAL_PAGES = 10;
+
+/**
  * DeltaSyncService handles incremental sync of Tana nodes
  * from the local API into the SQLite database.
  */
@@ -31,6 +55,8 @@ export class DeltaSyncService {
   private localApiClient: DeltaSyncOptions["localApiClient"];
   private embeddingConfig?: DeltaSyncOptions["embeddingConfig"];
   private logger: NonNullable<DeltaSyncOptions["logger"]>;
+  /** Explicit override from constructor options; if undefined, auto-scaled per sync from `sync_metadata.total_nodes`. */
+  private maxPagesOverride: number | undefined;
   private syncing = false;
 
   constructor(options: DeltaSyncOptions) {
@@ -44,6 +70,28 @@ export class DeltaSyncService {
       warn: () => {},
       error: () => {},
     };
+    this.maxPagesOverride = options.maxPages;
+  }
+
+  /**
+   * Compute the per-sync abort cap.
+   * - If the constructor was given an explicit `maxPages`, that wins.
+   * - Otherwise scale against `sync_metadata.total_nodes`: cap at
+   *   `MAX_PAGES_RATIO` of the graph.
+   * - If `total_nodes` is missing or zero, fall back to `FALLBACK_MAX_PAGES`.
+   *
+   * Note: for very small workspaces the scaled cap may round down to 1 page;
+   * that's inherent to page-quantized pagination, not a bug — the broken-API
+   * signature still trips at page 2.
+   */
+  private resolveMaxPages(): number {
+    if (this.maxPagesOverride !== undefined) return this.maxPagesOverride;
+    const row = this.db
+      .query("SELECT total_nodes FROM sync_metadata WHERE id = 1")
+      .get() as { total_nodes: number } | undefined;
+    const totalNodes = row?.total_nodes ?? 0;
+    if (totalNodes <= 0) return FALLBACK_MAX_PAGES;
+    return Math.ceil((totalNodes * MAX_PAGES_RATIO) / PAGE_SIZE);
   }
 
   /**
@@ -325,6 +373,9 @@ export class DeltaSyncService {
       // Use 0 as fallback watermark if null (first delta after full sync with no delta timestamp)
       const sinceMs = watermarkBefore ?? 0;
 
+      // Resolve the per-sync abort cap from current workspace size.
+      const maxPages = this.resolveMaxPages();
+
       // Step 3: Page through changed nodes
       let nodesFound = 0;
       let nodesInserted = 0;
@@ -336,7 +387,29 @@ export class DeltaSyncService {
 
       for await (const page of this.fetchChangedNodes(sinceMs)) {
         pages++;
+
+        if (pages > maxPages) {
+          // Rows merged on pages 1..maxPages are already committed to SQLite;
+          // the watermark is NOT advanced because we throw before Step 5.
+          // The next delta-sync will replay from the same `sinceMs` and
+          // re-merge those rows idempotently. Recovery is `supertag sync index`.
+          // Check fires BEFORE merging this page, so we don't do work we're
+          // about to throw away.
+          throw new Error(
+            `Delta-sync aborted after ${maxPages} pages (${nodesFound} nodes merged so far; watermark NOT advanced). ` +
+              `This usually means the Local API is not honoring 'edited.since' ` +
+              `and is returning the entire workspace. Run 'supertag sync index' ` +
+              `for a full sync instead, or raise maxPages if this is a legitimately large delta.`,
+          );
+        }
+
         nodesFound += page.length;
+
+        if (pages === 1 || pages % PROGRESS_INTERVAL_PAGES === 0) {
+          this.logger.info(
+            `delta-sync progress: ${pages} page(s), ${nodesFound} nodes (latest page: ${page.length})`,
+          );
+        }
 
         for (const node of page) {
           const result = this.mergeNode(node);

--- a/src/types/local-api.ts
+++ b/src/types/local-api.ts
@@ -362,6 +362,13 @@ export interface DeltaSyncOptions {
     warn(message: string, data?: Record<string, unknown>): void;
     error(message: string, data?: Record<string, unknown>): void;
   };
+  /**
+   * Explicit override for the abort cap on pages fetched per delta-sync.
+   * When omitted, the cap auto-scales from `sync_metadata.total_nodes`
+   * (25% of the graph). Guards against runaway loops when the Local API
+   * ignores `edited.since` and returns the entire workspace as "changed".
+   */
+  maxPages?: number;
 }
 
 /**

--- a/tests/unit/delta-sync-pagination.test.ts
+++ b/tests/unit/delta-sync-pagination.test.ts
@@ -50,9 +50,11 @@ function createDbWithFullSync(dbPath: string): void {
       total_nodes INTEGER NOT NULL DEFAULT 0
     )
   `);
-  // Insert a full sync record so delta-sync can proceed
+  // Insert a full sync record so delta-sync can proceed. total_nodes is set high
+  // enough that the auto-scaled abort cap (25% * total / PAGE_SIZE) doesn't trip
+  // unrelated tests that happen to page through dozens of results.
   db.run(
-    "INSERT INTO sync_metadata (id, last_export_file, last_sync_timestamp, total_nodes) VALUES (1, 'export.json', ?, 1000)",
+    "INSERT INTO sync_metadata (id, last_export_file, last_sync_timestamp, total_nodes) VALUES (1, 'export.json', ?, 1000000)",
     [Date.now() - 60000]
   );
   db.close();
@@ -379,6 +381,184 @@ describe("DeltaSyncService - Pagination + Sync Orchestration (T-2.2)", () => {
       const result = await service.sync();
       expect(result.embeddingsSkipped).toBe(true);
       expect(result.embeddingsGenerated).toBe(0);
+    });
+
+    it("logs a progress line on page 1 (Bug 6)", async () => {
+      const page1 = Array.from({ length: 100 }, (_, i) => createTestNode(`p1-${i}`, `Page1 Node ${i}`));
+      const page2 = Array.from({ length: 50 }, (_, i) => createTestNode(`p2-${i}`, `Page2 Node ${i}`));
+      const logs: string[] = [];
+
+      service = new DeltaSyncService({
+        dbPath,
+        localApiClient: {
+          searchNodes: async (_query, options) => {
+            const offset = options?.offset ?? 0;
+            if (offset === 0) return page1;
+            if (offset === 100) return page2;
+            return [];
+          },
+          health: async () => true,
+        },
+        logger: {
+          info: (msg) => logs.push(msg),
+          warn: () => {},
+          error: () => {},
+        },
+      });
+
+      await service.sync();
+
+      const progress = logs.filter((m) => m.startsWith("delta-sync progress:"));
+      // 2 pages total: page 1 logs, page 2 does not (< interval).
+      expect(progress).toHaveLength(1);
+      expect(progress[0]).toContain("1 page(s)");
+      expect(progress[0]).toContain("100 nodes");
+    });
+
+    it("emits a progress line every 10 pages (Bug 6)", async () => {
+      const logs: string[] = [];
+      let calls = 0;
+      const TOTAL_PAGES = 25;
+
+      service = new DeltaSyncService({
+        dbPath,
+        localApiClient: {
+          searchNodes: async () => {
+            calls++;
+            if (calls > TOTAL_PAGES) return [];
+            // Distinct ids per call so DB doesn't collide
+            return Array.from({ length: 100 }, (_, i) => createTestNode(`hb-${calls}-${i}`, `Heartbeat ${calls}-${i}`));
+          },
+          health: async () => true,
+        },
+        logger: {
+          info: (msg) => logs.push(msg),
+          warn: () => {},
+          error: () => {},
+        },
+      });
+
+      await service.sync();
+
+      const progress = logs.filter((m) => m.startsWith("delta-sync progress:"));
+      // Pages 1, 10, 20 — page 25 doesn't hit the interval.
+      expect(progress).toHaveLength(3);
+      expect(progress[0]).toContain("1 page(s)");
+      expect(progress[1]).toContain("10 page(s)");
+      expect(progress[2]).toContain("20 page(s)");
+    });
+
+    it("auto-scales the abort cap from total_nodes when no override is given (Bug 6)", async () => {
+      // total_nodes = 24000 → cap = ceil(24000 * 0.25 / 100) = 60 pages.
+      const reseedDb = new Database(dbPath);
+      reseedDb.run("UPDATE sync_metadata SET total_nodes = 24000 WHERE id = 1");
+      reseedDb.close();
+
+      let calls = 0;
+      service = new DeltaSyncService({
+        dbPath,
+        localApiClient: {
+          searchNodes: async () => {
+            calls++;
+            return Array.from({ length: 100 }, (_, i) =>
+              createTestNode(`scale-${calls}-${i}`, `Scale ${calls}-${i}`),
+            );
+          },
+          health: async () => true,
+        },
+        // no maxPages — let it auto-scale
+      });
+
+      await expect(service.sync()).rejects.toThrow(/aborted after 60 pages/);
+    });
+
+    it("auto-scaled cap scales down to small workspaces without a floor (Bug 6)", async () => {
+      // Small workspace: total_nodes = 4000 → cap = ceil(4000 * 0.25 / 100) = 10 pages.
+      // Critically the cap stays proportional rather than being raised to a floor;
+      // the broken-API failure mode (whole-workspace return = 40 pages here) trips.
+      const reseedDb = new Database(dbPath);
+      reseedDb.run("UPDATE sync_metadata SET total_nodes = 4000 WHERE id = 1");
+      reseedDb.close();
+
+      let calls = 0;
+      service = new DeltaSyncService({
+        dbPath,
+        localApiClient: {
+          searchNodes: async () => {
+            calls++;
+            return Array.from({ length: 100 }, (_, i) =>
+              createTestNode(`tiny-${calls}-${i}`, `Tiny ${calls}-${i}`),
+            );
+          },
+          health: async () => true,
+        },
+      });
+
+      await expect(service.sync()).rejects.toThrow(/aborted after 10 pages/);
+    });
+
+    it("explicit maxPages overrides the auto-scaled cap (Bug 6)", async () => {
+      // Even with total_nodes=24000 (auto-scaled cap would be 60), the explicit override wins.
+      const reseedDb = new Database(dbPath);
+      reseedDb.run("UPDATE sync_metadata SET total_nodes = 24000 WHERE id = 1");
+      reseedDb.close();
+
+      service = new DeltaSyncService({
+        dbPath,
+        localApiClient: {
+          searchNodes: async () => {
+            return Array.from({ length: 100 }, (_, i) =>
+              createTestNode(`ov-${i}`, `Override ${i}`),
+            );
+          },
+          health: async () => true,
+        },
+        maxPages: 3,
+      });
+
+      await expect(service.sync()).rejects.toThrow(/aborted after 3 pages/);
+    });
+
+    it("aborts with a clear error when maxPages is hit and leaves watermark unchanged (Bug 6)", async () => {
+      // Capture watermark from the test-db seed so we can assert it is NOT advanced on abort.
+      const seedDb = new Database(dbPath);
+      const watermarkBefore = (seedDb.query(
+        "SELECT last_sync_timestamp FROM sync_metadata WHERE id = 1",
+      ).get() as { last_sync_timestamp: number }).last_sync_timestamp;
+      seedDb.close();
+
+      service = new DeltaSyncService({
+        dbPath,
+        localApiClient: {
+          searchNodes: async (_q, options) => {
+            const offset = options?.offset ?? 0;
+            // Always return a full page → loop never stops naturally
+            return Array.from({ length: 100 }, (_, i) =>
+              createTestNode(`cap-${offset}-${i}`, `Cap ${offset}-${i}`),
+            );
+          },
+          health: async () => true,
+        },
+        maxPages: 3,
+      });
+
+      await expect(service.sync()).rejects.toThrow(
+        /Delta-sync aborted after 3 pages.*watermark NOT advanced.*supertag sync index/s,
+      );
+
+      // Watermark must NOT have advanced — next delta should replay from the same point.
+      const verifyDb = new Database(dbPath);
+      const watermarkAfter = (verifyDb.query(
+        "SELECT last_sync_timestamp FROM sync_metadata WHERE id = 1",
+      ).get() as { last_sync_timestamp: number }).last_sync_timestamp;
+      verifyDb.close();
+      expect(watermarkAfter).toBe(watermarkBefore);
+
+      // And rows from the pages that did complete should have been merged (idempotently replayable).
+      const verifyDb2 = new Database(dbPath);
+      const rowCount = (verifyDb2.query("SELECT COUNT(*) as c FROM nodes").get() as { c: number }).c;
+      verifyDb2.close();
+      expect(rowCount).toBeGreaterThan(0);
     });
 
     it("paginates through multiple pages", async () => {


### PR DESCRIPTION
## TL;DR

`supertag sync index --delta` silently hangs for an hour or more on large workspaces. Root cause: the Tana Desktop Local API drops the `edited.since` filter on `/nodes/search`, so what's supposed to be an incremental sync walks the entire graph. This PR doesn't fix the upstream filter (that's on Tana). It makes the failure visible and bounded so users don't wait an hour to find out something's wrong, and it points them to the fast recovery path (`supertag sync index`, no `--delta`).

This is a safety patch. The delta-sync feature itself is only as good as the upstream filter; until that's fixed, full-refresh is the practical workflow.

## Symptom

On a 739K-node workspace:

```
$ supertag sync index --delta
[INFO]  [tana-sync]  Workspace: main
...
(silence for 1h+)
```

No progress, no error, eventually completes with most of the workspace re-merged. First-time users will assume the CLI is broken or hung.

## Root cause (upstream, not this CLI)

Direct probe of the Tana Desktop Local API, bypassing this CLI entirely:

```
since=5 min ago    -> page1 100  page2 100  page3 100
since=1 hour ago   -> page1 100  page2 100  page3 100
since=1 day ago    -> page1 100  page2 100  page3 100
since=1 week ago   -> page1 100  page2 100  page3 100
since=1 year ago   -> page1 100  page2 100  page3 100
since=1 (epoch)    -> page1 100  page2 100  page3 100
```

Six orders of magnitude of `since` values, all return identical paginated results. The filter is being silently dropped. This is a Tana Desktop bug, not a `supertag-cli` bug. To my knowledge, this is the first surfaced report (no open or closed issues on this repo mention `edited.since`, `/nodes/search`, or delta-sync pagination behavior).

## The wider context: full sync is much faster anyway

While debugging this, I measured all three sync transports end-to-end on the same 739K-node workspace:

| Path | Mechanism | Wall time |
|---|---|---|
| `supertag-export run main` | Downloads Tana's server-cached snapshot (173 MB) | **9.1s** |
| `supertag sync index` | Reads local snapshot JSON, bulk-inserts to SQLite | **4.3s** |
| `supertag sync index --delta` (working) | Paginated HTTP to Local API, 100 nodes/page | minutes-to-hours, scales with changeset |
| `supertag sync index --delta` (broken, today) | Same path but server returns whole workspace | hangs indefinitely |

So a full refresh is `~13 seconds total` on a 739K-node graph. Even if the upstream filter is fixed tomorrow, `--delta` only wins when the actual changeset is small enough that page-by-page HTTP roundtrips beat a 9-second cached-snapshot download. That's a narrower regime than the current docs imply.

This PR is not advocating to remove `--delta` (there are legitimate uses: long-running watch loops, environments where Playwright is unavailable). But the recovery hint in the error message points users at the path they probably wanted anyway.

## Changes

### `src/services/delta-sync.ts`

- **Per-page progress logging.** Logs on page 1, then every 10th page. Turns the silent hang into observable progress.
- **Auto-scaled abort cap.** Cap = `ceil(sync_metadata.total_nodes * 0.25 / 100)` pages. The broken-API failure mode returns ~100% of the workspace, so any sub-100% threshold catches it; 25% leaves headroom for legitimately large deltas while bounding wasted work. Falls back to 1000 pages if `total_nodes` is missing.
- **Preserves `last_sync_timestamp` on abort.** When the cap fires, `sync_metadata.last_sync_timestamp` is **not** advanced. The next attempt replays from the same point and re-merges any rows that were already committed, idempotently. Error message tells the user to run `supertag sync index` (no `--delta`) for full resync.

### `src/types/local-api.ts`

- Adds optional `maxPages` to `DeltaSyncOptions` so callers can override the auto-scaled cap.

### `src/commands/sync.ts`

- Wires the existing `logger` through to `DeltaSyncService` in both the standalone `runDeltaSync` path and the `watch` path. Without this, the new progress lines defaulted to a no-op logger when invoked from the CLI and never surfaced. Drive-by but necessary for the fix to be visible to users.

### `tests/unit/delta-sync-pagination.test.ts`

7 new tests:

1. Progress line fires on page 1.
2. Heartbeat fires at pages 1, 10, 20 over a 25-page run.
3. Auto-scaled cap derives from `total_nodes` (24K nodes gives a 60-page cap).
4. Auto-scaled cap scales down proportionally (4K nodes gives a 10-page cap, no minimum floor).
5. Explicit `maxPages` override wins over the auto-scaled value.
6. Abort throws with the documented error message plus `supertag sync index` hint.
7. After abort, `last_sync_timestamp` is unchanged; merged rows are present (idempotent replay).

Fixture seed bumped: `total_nodes` 1000 to 1000000 so the new auto-scaled cap doesn't trip unrelated pagination tests.

All 19 tests in `delta-sync-pagination.test.ts` pass. No other test files modified.

## Verification

Live-tested against the 739K-node workspace that originally exhibited the hang:

- Per-page progress lines surfaced as expected.
- Auto-scaled cap fired at **1849 pages** (`ceil(739455 * 0.25 / 100)`), aborted with the documented error.
- Total runtime in the minutes range instead of 1h+.

## Recommended follow-ups (out of scope for this PR)

1. **Confirm and file the upstream Tana bug.** Probe evidence above is reproducible; happy to share the test script.
2. **Consider updating `--delta` docs** to mention the full-sync alternative and its current speed advantage. (Not making doc changes in this PR to keep the scope tight.)
3. **Eventually:** if Tana fixes the filter, the cap becomes a dormant safety net. If they don't, it might be worth deprecating `--delta` in favor of cached-snapshot refresh as the default sync path.

## Notes for reviewers

- The `MAX_PAGES_RATIO = 0.25` constant is the main tunable. I considered 0.5 (more headroom) but settled on 0.25 because the broken-API failure mode is so distinctive (whole-workspace return) that there's no risk of false-positive aborts at 25%, and lower thresholds reduce wasted work.
- No floor on the auto-scaled cap on purpose: very small workspaces should also be protected proportionally. Test 4 covers this.
- Holding `last_sync_timestamp` steady on abort is the subtle correctness property. It's what makes the abort safe to retry rather than corrupt-on-retry. Test 7 pins it.