### PR TITLE
fix(ci): codesign + verify + smoke-test macOS binaries (fixes #84)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,6 +89,40 @@ jobs:
             bun build export/index.ts --compile --target=${{ matrix.target }} $EXTERNAL_FLAGS --outfile=supertag-export
           fi
 
+      # Apple Silicon (and increasingly x64 on macOS 26+) kills any Mach-O that
+      # lacks a valid code signature with SIGKILL (exit 137) at exec — no
+      # Gatekeeper dialog, quarantine removal does nothing. Bun's --compile
+      # *usually* ad-hoc signs, but some Bun versions (and cross-compiled
+      # targets) ship UNSIGNED binaries, which is exactly how #84 escaped for a
+      # month. Re-sign explicitly here so we never depend on Bun's auto-signing.
+      # --remove-signature first clears any malformed/partial signature that
+      # would otherwise make `codesign --force` fail with "invalid format".
+      - name: Codesign macOS binaries (ad-hoc)
+        run: |
+          set -euo pipefail
+          for bin in supertag supertag-lite supertag-mcp supertag-export; do
+            codesign --remove-signature "$bin" 2>/dev/null || true
+            codesign --force --sign - --timestamp=none "$bin"
+            codesign --verify --verbose "$bin"
+          done
+
+      # Verification gate: actually EXECUTE the binaries. This is the check that
+      # would have caught #84 in CI instead of a month later. macos-latest is
+      # arm64, so the arm64 matrix binaries run natively; x64 binaries run under
+      # Rosetta when available, otherwise we skip the run and rely on --verify.
+      - name: Smoke-test binaries
+        run: |
+          set -euo pipefail
+          if [ "${{ matrix.target }}" = "bun-darwin-arm64" ]; then
+            ./supertag --version
+            ./supertag-lite --version
+          elif arch -x86_64 true 2>/dev/null; then
+            arch -x86_64 ./supertag --version
+            arch -x86_64 ./supertag-lite --version
+          else
+            echo "Rosetta unavailable; skipping x64 execution (signature verified above)"
+          fi
+
       - name: Create distribution package
         run: |
           DIST_NAME="supertag-cli-${{ matrix.suffix }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,22 +106,43 @@ jobs:
             codesign --verify --verbose "$bin"
           done
 
-      # Verification gate: actually EXECUTE the binaries. This is the check that
-      # would have caught #84 in CI instead of a month later. macos-latest is
-      # arm64, so the arm64 matrix binaries run natively; x64 binaries run under
-      # Rosetta when available, otherwise we skip the run and rely on --verify.
+      # Verification gate: actually EXECUTE every binary. This is the check that
+      # would have caught #84 in CI instead of a month later. An unsigned Mach-O
+      # is SIGKILLed by the kernel at exec (exit 137) on Apple Silicon, so we
+      # only need to prove each binary *starts*. supertag/-lite/-export exit
+      # cleanly on --version; supertag-mcp ignores the flag and runs as a stdio
+      # server, so we use a background guard (no GNU `timeout` on macOS runners):
+      # launch, wait 2s, and if it's still alive it execed fine (kill = pass);
+      # otherwise the only failure we care about is 137 (kernel SIGKILL).
       - name: Smoke-test binaries
         run: |
-          set -euo pipefail
+          set -uo pipefail
+          RUNNER=""
           if [ "${{ matrix.target }}" = "bun-darwin-arm64" ]; then
-            ./supertag --version
-            ./supertag-lite --version
+            RUNNER=""                       # native arm64 on macos-latest
           elif arch -x86_64 true 2>/dev/null; then
-            arch -x86_64 ./supertag --version
-            arch -x86_64 ./supertag-lite --version
+            RUNNER="arch -x86_64"           # x64 via Rosetta
           else
-            echo "Rosetta unavailable; skipping x64 execution (signature verified above)"
+            echo "Rosetta unavailable; skipping x64 execution (signatures verified above)"
+            exit 0
           fi
+          smoke() {
+            local bin="$1"
+            $RUNNER "./$bin" --version </dev/null >/dev/null 2>&1 &
+            local pid=$!
+            sleep 2
+            if kill -0 "$pid" 2>/dev/null; then
+              kill "$pid" 2>/dev/null; wait "$pid" 2>/dev/null || true
+              echo "ok: $bin started (long-running; killed after 2s)"
+            else
+              wait "$pid"; local rc=$?
+              if [ "$rc" -eq 137 ]; then
+                echo "FAIL: $bin was SIGKILLed (exit 137) — invalid/missing code signature"; exit 1
+              fi
+              echo "ok: $bin exited $rc"
+            fi
+          }
+          for b in supertag supertag-lite supertag-mcp supertag-export; do smoke "$b"; done
 
       - name: Create distribution package
         run: |


### PR DESCRIPTION
Fixes #84.

## Problem

All pre-built macOS binaries (`supertag`, `supertag-lite`, `supertag-mcp`) exit **137 (SIGKILL)** immediately on Apple Silicon / macOS 26 — no Gatekeeper dialog, quarantine removal has no effect, killed even from Terminal. Reported by two users; open ~1 month.

## Root cause (verified empirically on a macOS 26 / Apple Silicon host)

The shipped binaries are **completely unsigned**:
```
$ codesign -dv supertag      # from v2.5.7 release asset
supertag: code object is not signed at all
$ ./supertag --version; echo $?
137
```
On Apple Silicon the kernel (AMFI) SIGKILLs any unsigned Mach-O at exec. Not JIT/entitlements/LanceDB — just a missing signature.

The release workflow built with `bun-version: latest` and relied on Bun's `--compile` to ad-hoc-sign automatically. Some Bun versions stopped doing that → unsigned binaries shipped. **Nothing in CI executed or signature-checked the output**, so it went unnoticed for a month.

## Fix

- **Explicit ad-hoc codesign** of every macOS binary: `codesign --remove-signature` first (clears any malformed partial signature that otherwise makes `--force` fail with "invalid format"), then `codesign --force --sign - --timestamp=none`, then `codesign --verify`.
- **Smoke-test gate**: execute `--version` on the built binaries (arm64 natively on the macos-latest runner; x64 via Rosetta when available). This is the check that would have caught #84 in CI rather than in users' hands.

## Verification

On macOS 26 / Apple Silicon: remove-sig + ad-hoc sign + verify + run → exit 0. The same procedure salvages already-downloaded binaries (documented as an immediate workaround in #84).

## Scope / follow-up

Ad-hoc signing stops the SIGKILL but downloaders still get a one-time Gatekeeper "unidentified developer" prompt. Zero-friction distribution needs Developer ID signing + notarization (Apple Developer account + CI secrets) — separate, larger task; worth a follow-up issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)