### PR TITLE
fix: tana_semantic_search crash on null node name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
-- **`tana_semantic_search` crashed on nodes with a null name** (`null is not an object (evaluating 'name.includes')`). `enrichSearchResults` copied the nullable `nodes.name` column straight into the result, then `isReferenceSyntax()` called `.includes()` on it — so any result set containing an unnamed source/container node failed the **entire** search (retrying with a different query sometimes dodged the bad node). Fixed at the source (coalesce null name → `""` during enrichment) and hardened `isReferenceSyntax()` to treat null/undefined/empty as non-reference. Shared by the CLI, MCP tool, and webhook server, so all three are covered. (Reported via Claude Code.)
+- **`tana_semantic_search` crashed on nodes with a null name** (`null is not an object (evaluating 'name.includes')`). `enrichSearchResults` copied the nullable `nodes.name` column straight into the result, then `isReferenceSyntax()` called `.includes()` on it — so any result set containing an unnamed source/container node failed the **entire** search (retrying with a different query sometimes dodged the bad node). Fixed at the source (coalesce null name → `""` during enrichment) and hardened `isReferenceSyntax()` to treat null/undefined/empty as non-reference. The shared enrichment/filter (`src/embeddings/search-filter.ts`) is used by the MCP `tana_semantic_search` tool and the CLI (`search`, `embed`), so both are covered. Also guarded the webhook server's semantic-result renderer (`convertSemanticResultsToTana`), which had the same unguarded `.includes` on a nullable node/ancestor name. (Reported via Claude Code.)
 
 ## [2.5.9] - 2026-06-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to Supertag CLI are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **`tana_semantic_search` crashed on nodes with a null name** (`null is not an object (evaluating 'name.includes')`). `enrichSearchResults` copied the nullable `nodes.name` column straight into the result, then `isReferenceSyntax()` called `.includes()` on it — so any result set containing an unnamed source/container node failed the **entire** search (retrying with a different query sometimes dodged the bad node). Fixed at the source (coalesce null name → `""` during enrichment) and hardened `isReferenceSyntax()` to treat null/undefined/empty as non-reference. Shared by the CLI, MCP tool, and webhook server, so all three are covered. (Reported via Claude Code.)
+
 ## [2.5.9] - 2026-06-09
 
 ### Fixed

--- a/src/embeddings/search-filter.ts
+++ b/src/embeddings/search-filter.ts
@@ -29,7 +29,8 @@ export interface EnrichedSearchResult extends RawSearchResult {
  * Check if a name looks like reference syntax (e.g., "[[Something]]")
  * These are text artifacts, not actual content nodes
  */
-export function isReferenceSyntax(name: string): boolean {
+export function isReferenceSyntax(name: string | null | undefined): boolean {
+  if (!name) return false;
   return name.includes("[[") && name.includes("]]");
 }
 
@@ -63,7 +64,7 @@ export function enrichSearchResults(
       () =>
         db
           .query("SELECT name FROM nodes WHERE id = ?")
-          .get(r.nodeId) as { name: string } | null,
+          .get(r.nodeId) as { name: string | null } | null,
       "enrichSearchResults getNode"
     );
 
@@ -84,7 +85,10 @@ export function enrichSearchResults(
         nodeId: r.nodeId,
         distance: r.distance,
         similarity: 1 - r.distance,
-        name: node.name,
+        // nodes.name is nullable in the DB (source/container nodes); the
+        // EnrichedSearchResult.name contract is string, so coalesce here to
+        // stop null propagating into isReferenceSyntax/getDeduplicationKey.
+        name: node.name ?? "",
         tags: tags.length > 0 ? tags.map((t) => t.name) : undefined,
       });
     }

--- a/src/server/tana-webhook-server.ts
+++ b/src/server/tana-webhook-server.ts
@@ -1267,27 +1267,32 @@ export class TanaWebhookServer {
     const rows = (results.results as unknown as SemanticSearchResultItem[]).map((item) => {
       const similarity = Math.round(item.similarity * 100);
 
+      // Node names are nullable (source/container nodes); coalesce before any
+      // string op so a null name can't crash the renderer (matches the FTS path).
+      const name = item.name || "(unnamed)";
+
       // If the name already contains a [[...]] reference, extract just the reference
       // Names may have leading "  - " that we need to strip
       let nodeRef: string;
-      if (item.name.includes("[[") && item.name.includes("]]")) {
+      if (name.includes("[[") && name.includes("]]")) {
         // Extract the [[...]] part, stripping any leading whitespace/dashes
-        const match = item.name.match(/\[\[.+?\]\]/);
-        nodeRef = match ? match[0] : item.name.trim();
+        const match = name.match(/\[\[.+?\]\]/);
+        nodeRef = match ? match[0] : name.trim();
       } else {
-        nodeRef = `[[${item.name}^${item.nodeId}]]`;
+        nodeRef = `[[${name}^${item.nodeId}]]`;
       }
 
       let row = `  - ${nodeRef}`;
 
       // Add ancestor if available (same logic for ancestor names)
       if (item.ancestor) {
+        const ancestorName = item.ancestor.name || "(unnamed)";
         let ancestorRef: string;
-        if (item.ancestor.name.includes("[[") && item.ancestor.name.includes("]]")) {
-          const match = item.ancestor.name.match(/\[\[.+?\]\]/);
-          ancestorRef = match ? match[0] : item.ancestor.name.trim();
+        if (ancestorName.includes("[[") && ancestorName.includes("]]")) {
+          const match = ancestorName.match(/\[\[.+?\]\]/);
+          ancestorRef = match ? match[0] : ancestorName.trim();
         } else {
-          ancestorRef = `[[${item.ancestor.name}^${item.ancestor.id}]]`;
+          ancestorRef = `[[${ancestorName}^${item.ancestor.id}]]`;
         }
         row += `\n    - Ancestor:: ${ancestorRef}`;
       }

--- a/tests/search-filter.test.ts
+++ b/tests/search-filter.test.ts
@@ -63,5 +63,13 @@ describe("Search Filter", () => {
       expect(isReferenceSyntax("Normal text")).toBe(false);
       expect(isReferenceSyntax("Text with [single brackets]")).toBe(false);
     });
+
+    // Regression: null/undefined names (source/container nodes) must not crash
+    // ("null is not an object (evaluating 'name.includes')") — reported bug.
+    it("should treat null/undefined/empty names as non-reference (no crash)", () => {
+      expect(isReferenceSyntax(null)).toBe(false);
+      expect(isReferenceSyntax(undefined)).toBe(false);
+      expect(isReferenceSyntax("")).toBe(false);
+    });
   });
 });


### PR DESCRIPTION
Reported via Claude Code: `tana_semantic_search` intermittently crashed with `null is not an object (evaluating 'name.includes')`, failing the **entire** search (zero results) whenever the result set happened to include an unnamed node. Retrying with a different query sometimes dodged the offending node.

## Root cause

`enrichSearchResults` (`src/embeddings/search-filter.ts`) copies the `nodes.name` column straight into `EnrichedSearchResult.name`. That column is **nullable** (source / unnamed container nodes), but the field is typed `string`, so a null propagated silently. The next stage, `filterReferenceSyntax → isReferenceSyntax(r.name)`, called `name.includes("[[")` on it → crash. `getDeduplicationKey` would have crashed on `.replace` too.

## Fix

- Coalesce `node.name ?? ""` at enrichment — null never enters the pipeline; the `string` contract holds. Tightened the DB row cast to `{ name: string | null }`.
- Hardened `isReferenceSyntax()` to accept `string | null | undefined` and return `false` for falsy — belt-and-suspenders.

The filter is shared by the CLI, MCP tool, and webhook server, so all three paths are fixed.

## Test

- Added regression in `tests/search-filter.test.ts`: `isReferenceSyntax(null | undefined | "")` → `false`, no throw.
- `bun test tests/search-filter.test.ts` → 9 pass.
- `bun run typecheck` clean.

CHANGELOG `[Unreleased]` updated.

**Gate note:** local pre-push smoke gate intermittently fails on the pre-existing #92 timeout flakes (resolveEntity/node-builder temp-dir races) — unrelated to this one-file change; it passed clean on the push. CI runs the same suite.