### PR TITLE
test: gate real-DB/CLI tests out of the fast pre-push suite + fixture-convert transcript queries

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,10 @@ jobs:
         run: bun install
 
       - name: Run tests
-        run: bun run test --timeout 30000
+        # RUN_INTEGRATION=1 includes the CLI-subprocess e2e suites (gated out of
+        # the local pre-push fast suite for speed). Real-DB-only suites still
+        # self-skip on CI since no workspace database is built here.
+        run: RUN_INTEGRATION=1 bun run test
 
       - name: Type check
         run: bun run typecheck

--- a/package.json
+++ b/package.json
@@ -14,9 +14,10 @@
     "dev": "bun run src/index.ts",
     "dev:mcp": "bun run src/mcp/index.ts",
     "inspect:mcp": "npx @modelcontextprotocol/inspector bun run src/mcp/index.ts",
-    "test": "bun test ./tests/*.test.ts ./tests/codegen/ ./tests/commands/ ./tests/config/ ./tests/db/ ./tests/e2e/ ./tests/embeddings/ ./tests/integration/ ./tests/mcp/ ./tests/services/ ./tests/types/ ./tests/unit/ ./tests/utils/ ./tests/visualization/ ./tests/watch/ ./src/**/*.test.ts",
+    "test": "bun test --timeout 30000 ./tests/*.test.ts ./tests/codegen/ ./tests/commands/ ./tests/config/ ./tests/db/ ./tests/e2e/ ./tests/embeddings/ ./tests/integration/ ./tests/mcp/ ./tests/services/ ./tests/types/ ./tests/unit/ ./tests/utils/ ./tests/visualization/ ./tests/watch/ ./src/**/*.test.ts",
+    "test:integration": "RUN_INTEGRATION=1 bun run test",
     "test:slow": "bun test ./tests/slow/",
-    "test:full": "bun test --bail",
+    "test:full": "RUN_INTEGRATION=1 bun test --bail",
     "typecheck": "tsc --noEmit",
     "precommit": "bun run test:full"
   },

--- a/tests/commands/search-field-filter.test.ts
+++ b/tests/commands/search-field-filter.test.ts
@@ -6,13 +6,14 @@
  */
 
 import { describe, it, expect, beforeAll, afterAll } from "bun:test";
+import { describeIntegration } from "../helpers/integration-gate";
 import { mkdirSync, rmSync, existsSync, writeFileSync } from "fs";
 import { join } from "path";
 import { $ } from "bun";
 import { Database } from "bun:sqlite";
 import { migrateSupertagMetadataSchema } from "../../src/db/migrate";
 
-describe("Search Field Filter CLI Commands", () => {
+describeIntegration("Search Field Filter CLI Commands", () => {
   const testDir = join(process.cwd(), "tmp-test-search-field-filter");
   const dbPath = join(testDir, "main", "tana-index.db");
   const configPath = join(testDir, "config.json");

--- a/tests/commands/tags-metadata.test.ts
+++ b/tests/commands/tags-metadata.test.ts
@@ -5,6 +5,7 @@
  */
 
 import { describe, it, expect, beforeAll, afterAll, beforeEach } from "bun:test";
+import { describeIntegration } from "../helpers/integration-gate";
 import { mkdirSync, rmSync, existsSync, writeFileSync } from "fs";
 import { join } from "path";
 import { $ } from "bun";
@@ -12,7 +13,7 @@ import { Database } from "bun:sqlite";
 import { migrateSupertagMetadataSchema, migrateSchemaConsolidation } from "../../src/db/migrate";
 import { migrateSystemFieldSources } from "../../src/db/system-fields";
 
-describe("Tags Metadata CLI Commands", () => {
+describeIntegration("Tags Metadata CLI Commands", () => {
   const testDir = join(process.cwd(), "tmp-test-tags-metadata");
   const dbPath = join(testDir, "main", "tana-index.db");
   const configPath = join(testDir, "config.json");

--- a/tests/commands/tags-visualize.test.ts
+++ b/tests/commands/tags-visualize.test.ts
@@ -5,13 +5,14 @@
  */
 
 import { describe, it, expect, beforeAll, afterAll } from "bun:test";
+import { describeIntegration } from "../helpers/integration-gate";
 import { $ } from "bun";
 import { Database } from "bun:sqlite";
 import { mkdirSync, rmSync, existsSync, readFileSync, writeFileSync } from "fs";
 import { join } from "path";
 import { getUniqueTestDir } from "../test-utils";
 
-describe("tags visualize command", () => {
+describeIntegration("tags visualize command", () => {
   const testDir = getUniqueTestDir("visualize");
   const testDbPath = join(testDir, "tana-index.db");
 

--- a/tests/commands/transcript.test.ts
+++ b/tests/commands/transcript.test.ts
@@ -5,13 +5,14 @@
  */
 
 import { describe, it, expect, beforeAll, afterAll } from "bun:test";
+import { describeIntegration } from "../helpers/integration-gate";
 import { $ } from "bun";
 import { Database } from "bun:sqlite";
 import { existsSync } from "fs";
 import { getDatabasePath, resolveWorkspace } from "../../src/config/paths";
 import { ConfigManager } from "../../src/config/manager";
 
-describe("Transcript CLI Commands", () => {
+describeIntegration("Transcript CLI Commands", () => {
   let hasTranscripts: boolean = false;
   let dbPath: string;
   let dbAvailable: boolean = false;

--- a/tests/db/transcript-fixture.test.ts
+++ b/tests/db/transcript-fixture.test.ts
@@ -6,9 +6,11 @@
  *
  * Scope note: searchTranscripts here exercises the LIKE fallback path (the
  * fixture intentionally creates no `nodes_fts` table). The FTS search path and
- * the full live-data behaviour remain covered by transcript.test.ts, which is
- * gated behind RUN_INTEGRATION — so this is not a full equivalent of that
- * integration suite, just deterministic coverage of the core query shapes.
+ * full live-data behaviour are exercised only by transcript.test.ts, which is
+ * gated behind RUN_INTEGRATION and self-skips unless a real workspace DB with
+ * transcript data is present — so that coverage is opportunistic/local, NOT
+ * guaranteed on CI. This file is therefore the only CI-guaranteed coverage of
+ * these queries, and only of the LIKE/core-shape path.
  */
 import { describe, it, expect } from "bun:test";
 import {

--- a/tests/db/transcript-fixture.test.ts
+++ b/tests/db/transcript-fixture.test.ts
@@ -1,9 +1,14 @@
 /**
  * Deterministic, hermetic tests for the transcript data-access layer.
  *
- * Replaces the live-DB integration coverage (see transcript.test.ts, which is
- * now gated behind RUN_INTEGRATION) with an in-memory fixture so these queries
- * run fast and on CI. Pure helpers are covered here too.
+ * Covers the query *logic* of getMeetingsWithTranscripts and searchTranscripts
+ * against an in-memory fixture so it runs fast and on CI. Pure helpers too.
+ *
+ * Scope note: searchTranscripts here exercises the LIKE fallback path (the
+ * fixture intentionally creates no `nodes_fts` table). The FTS search path and
+ * the full live-data behaviour remain covered by transcript.test.ts, which is
+ * gated behind RUN_INTEGRATION — so this is not a full equivalent of that
+ * integration suite, just deterministic coverage of the core query shapes.
  */
 import { describe, it, expect } from "bun:test";
 import {

--- a/tests/db/transcript-fixture.test.ts
+++ b/tests/db/transcript-fixture.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Deterministic, hermetic tests for the transcript data-access layer.
+ *
+ * Replaces the live-DB integration coverage (see transcript.test.ts, which is
+ * now gated behind RUN_INTEGRATION) with an in-memory fixture so these queries
+ * run fast and on CI. Pure helpers are covered here too.
+ */
+import { describe, it, expect } from "bun:test";
+import {
+  isTranscriptNode,
+  formatTranscriptTime,
+  getMeetingsWithTranscripts,
+  searchTranscripts,
+} from "../../src/db/transcript";
+import { buildTranscriptFixtureDb } from "../helpers/transcript-fixture";
+
+describe("Transcript helpers (hermetic)", () => {
+  it("isTranscriptNode identifies transcript docTypes", () => {
+    expect(isTranscriptNode("transcript")).toBe(true);
+    expect(isTranscriptNode("transcriptLine")).toBe(true);
+    expect(isTranscriptNode("node")).toBe(false);
+    expect(isTranscriptNode(null)).toBe(false);
+    expect(isTranscriptNode(undefined)).toBe(false);
+  });
+
+  it("formatTranscriptTime converts ISO to MM:SS", () => {
+    expect(formatTranscriptTime("1970-01-01T00:35:58.004Z")).toBe("35:58");
+    expect(formatTranscriptTime("1970-01-01T01:05:30.000Z")).toBe("65:30");
+    expect(formatTranscriptTime("1970-01-01T00:00:00.000Z")).toBe("0:00");
+  });
+});
+
+describe("getMeetingsWithTranscripts (fixture)", () => {
+  it("returns meetings that have a SYS_A199 transcript link, with line counts", () => {
+    const db = buildTranscriptFixtureDb();
+    const results = getMeetingsWithTranscripts(db, { limit: 10 });
+    db.close();
+
+    expect(results).toHaveLength(1);
+    expect(results[0].meetingId).toBe("m1");
+    expect(results[0].meetingName).toBe("Weekly Sync");
+    expect(results[0].transcriptId).toBe("v1");
+    expect(results[0].lineCount).toBe(2);
+  });
+
+  it("respects the limit option", () => {
+    const db = buildTranscriptFixtureDb();
+    const results = getMeetingsWithTranscripts(db, { limit: 0 });
+    db.close();
+    expect(results).toHaveLength(0);
+  });
+});
+
+describe("searchTranscripts (fixture, LIKE fallback)", () => {
+  it("finds transcript lines by content and resolves the speaker", () => {
+    const db = buildTranscriptFixtureDb();
+    const results = searchTranscripts(db, "roadmap");
+    db.close();
+
+    expect(results).toHaveLength(1);
+    expect(results[0].lineId).toBe("ln1");
+    expect(results[0].lineText).toBe("Discussing the roadmap");
+    expect(results[0].speaker).toBe("Alice");
+  });
+
+  it("returns nothing for a non-matching query", () => {
+    const db = buildTranscriptFixtureDb();
+    const results = searchTranscripts(db, "zzz-no-such-content");
+    db.close();
+    expect(results).toHaveLength(0);
+  });
+
+  it("only matches transcriptLine nodes", () => {
+    const db = buildTranscriptFixtureDb();
+    // "Weekly Sync" is a meeting name, not a transcriptLine — must not match.
+    const results = searchTranscripts(db, "Weekly");
+    db.close();
+    expect(results).toHaveLength(0);
+  });
+});

--- a/tests/db/transcript.test.ts
+++ b/tests/db/transcript.test.ts
@@ -6,6 +6,7 @@
  */
 
 import { describe, it, expect, beforeAll, afterAll, setDefaultTimeout } from "bun:test";
+import { describeIntegration } from "../helpers/integration-gate";
 
 // Transcript queries can be slow due to JSON extraction on large datasets
 setDefaultTimeout(30000);
@@ -25,7 +26,10 @@ import {
   type TranscriptSearchResult,
 } from "../../src/db/transcript";
 
-describe("Transcript Data Access", () => {
+// Live-DB integration coverage. The deterministic, CI-running version of these
+// queries lives in transcript-fixture.test.ts; this suite exercises them against
+// the real workspace database and only runs under RUN_INTEGRATION=1.
+describeIntegration("Transcript Data Access", () => {
   let db: Database | null = null;
   let hasTranscripts: boolean = false;
 

--- a/tests/helpers/integration-gate.ts
+++ b/tests/helpers/integration-gate.ts
@@ -1,0 +1,22 @@
+/**
+ * Integration test gate.
+ *
+ * Some test suites drive the real CLI as a subprocess (`bun run src/index.ts …`)
+ * and/or query the live workspace database (the 854k-node `main` index). They are:
+ *   - slow (each CLI spawn recompiles TypeScript; real queries scan a large DB),
+ *   - non-deterministic (assert against whatever data happens to be in the export),
+ *   - invisible on CI (no DB is built there, so they self-skip anyway).
+ *
+ * Running them in the pre-push fast gate is what makes that gate flake under load
+ * (wall time blows past the smoke-test timeout). Wrap their top-level `describe`
+ * with `describeIntegration` so they are skipped by default and only run when
+ * `RUN_INTEGRATION=1` is set (the `test:integration` and `test:full` scripts).
+ *
+ *   import { describeIntegration } from "../helpers/integration-gate";
+ *   describeIntegration("CLI: tags metadata", () => { ... });
+ */
+import { describe } from "bun:test";
+
+export const RUN_INTEGRATION = process.env.RUN_INTEGRATION === "1";
+
+export const describeIntegration = RUN_INTEGRATION ? describe : describe.skip;

--- a/tests/helpers/integration-gate.ts
+++ b/tests/helpers/integration-gate.ts
@@ -1,16 +1,21 @@
 /**
  * Integration test gate.
  *
- * Some test suites drive the real CLI as a subprocess (`bun run src/index.ts …`)
- * and/or query the live workspace database (the 854k-node `main` index). They are:
- *   - slow (each CLI spawn recompiles TypeScript; real queries scan a large DB),
- *   - non-deterministic (assert against whatever data happens to be in the export),
- *   - invisible on CI (no DB is built there, so they self-skip anyway).
+ * Some test suites are too heavy for the pre-push fast gate, for two distinct
+ * reasons:
+ *   1. They drive the real CLI as a subprocess (`bun run src/index.ts …`), which
+ *      recompiles TypeScript on every call — slow regardless of the DB. These
+ *      build their own temp fixture DB and DO run on CI (e.g. tags-metadata,
+ *      tags-visualize, search-field-filter); they are gated purely for wall time.
+ *   2. They query the live workspace database (the 854k-node `main` index) — slow,
+ *      non-deterministic, and self-skipping on CI where no DB exists (e.g.
+ *      commands/transcript, select-parameter, db/transcript).
  *
- * Running them in the pre-push fast gate is what makes that gate flake under load
- * (wall time blows past the smoke-test timeout). Wrap their top-level `describe`
- * with `describeIntegration` so they are skipped by default and only run when
- * `RUN_INTEGRATION=1` is set (the `test:integration` and `test:full` scripts).
+ * Both kinds blow the fast suite past the smoke-test timeout under load. Wrap
+ * their top-level `describe` with `describeIntegration` so they are skipped by
+ * default and only run when `RUN_INTEGRATION=1` is set — locally via
+ * `test:integration`/`test:full`, and on CI (which sets it, so the category-1
+ * temp-DB e2e suites keep their coverage there).
  *
  *   import { describeIntegration } from "../helpers/integration-gate";
  *   describeIntegration("CLI: tags metadata", () => { ... });

--- a/tests/helpers/transcript-fixture.ts
+++ b/tests/helpers/transcript-fixture.ts
@@ -1,0 +1,59 @@
+/**
+ * Deterministic in-memory fixture for the transcript data-access queries.
+ *
+ * Models the minimal Tana node graph that `getMeetingsWithTranscripts` and
+ * `searchTranscripts` (LIKE fallback — no `nodes_fts` table is created) walk:
+ *
+ *   meeting (m1)
+ *     └─ metanode (_ownerId=m1) ─ children:[tuple]
+ *          └─ tuple ─ children:['SYS_A199', transcript]   ← SYS_A199 = transcript link
+ *               └─ transcript (_docType=transcript) ─ children:[line1, line2]
+ *
+ *   line1 (_docType=transcriptLine, "Discussing the roadmap")
+ *     └─ metanode (_ownerId=line1) ─ children:[tuple]
+ *          └─ tuple ─ children:['SYS_A252', speaker]       ← SYS_A252 = speaker
+ *               └─ speaker ("Alice")
+ *   line2 (_docType=transcriptLine, "Action items for next week")
+ *
+ * Replaces the old suite's dependency on the live 854k-node workspace DB, so
+ * these queries are tested deterministically and run on CI.
+ */
+import { Database } from "bun:sqlite";
+
+export function buildTranscriptFixtureDb(): Database {
+  const db = new Database(":memory:");
+  db.run(
+    `CREATE TABLE nodes (
+       id TEXT PRIMARY KEY,
+       name TEXT,
+       created INTEGER,
+       raw_data TEXT
+     )`
+  );
+
+  const insert = db.prepare(
+    `INSERT INTO nodes (id, name, created, raw_data) VALUES (?, ?, ?, ?)`
+  );
+  const node = (id: string, name: string | null, created: number, raw: unknown) =>
+    insert.run(id, name, created, JSON.stringify(raw));
+
+  // Meeting (owner is not a *_TRASH node, so it survives the WHERE filter)
+  node("m1", "Weekly Sync", 2000, { props: { _ownerId: "WS_OWNER" } });
+  // Metanode attaching the transcript tuple to the meeting
+  node("meta_m1", null, 0, { props: { _ownerId: "m1", _docType: "metanode" }, children: ["t1"] });
+  // Tuple: SYS_A199 marks a transcript link -> transcript v1
+  node("t1", null, 0, { children: ["SYS_A199", "v1"] });
+  // Transcript node with two lines (line_count = 2)
+  node("v1", null, 0, { props: { _docType: "transcript" }, children: ["ln1", "ln2"] });
+
+  // Transcript lines
+  node("ln1", "Discussing the roadmap", 0, { props: { _docType: "transcriptLine" } });
+  node("ln2", "Action items for next week", 0, { props: { _docType: "transcriptLine" } });
+
+  // Speaker metadata for ln1: metanode -> tuple(SYS_A252 -> speaker node "Alice")
+  node("meta_ln1", null, 0, { props: { _ownerId: "ln1", _docType: "metanode" }, children: ["st1"] });
+  node("st1", null, 0, { children: ["SYS_A252", "spk1"] });
+  node("spk1", "Alice", 0, {});
+
+  return db;
+}

--- a/tests/select-parameter.test.ts
+++ b/tests/select-parameter.test.ts
@@ -6,6 +6,7 @@
  */
 
 import { describe, it, expect, beforeAll } from "bun:test";
+import { describeIntegration } from "./helpers/integration-gate";
 import { $ } from "bun";
 import { existsSync } from "fs";
 import { getDatabasePath } from "../src/config/paths";
@@ -14,7 +15,7 @@ import { getDatabasePath } from "../src/config/paths";
 const dbPath = getDatabasePath();
 const hasDatabase = existsSync(dbPath);
 
-describe("--select parameter support", () => {
+describeIntegration("--select parameter support", () => {
   const testFn = hasDatabase ? it : it.skip;
 
   describe("tags list --select", () => {


### PR DESCRIPTION
Addresses the recurring pre-push gate flakiness (#92).

## Diagnosis (working theory, from this session's observations)

The "fast" suite (what the pre-push smoke gate and CI run) mixes hermetic unit tests with suites that either drive the CLI as a subprocess (`bun run src/index.ts …`, recompiling TS each call) or query the live 854k-node workspace DB through service internals. Those suites:

- **self-skip on CI** (no DB is built there) → they protect nothing in CI;
- assert weakly against whatever data happens to be present locally;
- are slow, so they dominate wall time.

Observed (not a controlled benchmark — single runs on a dev laptop, `bun run test`, load = 1-min `uptime` average): ~57s at load ~14, ~28s at load ~31 after this change, and a 360s `SIGTERM` from the pre-push hook's `execSync` cap during pushes when load was ~60. I did not capture/attach the gate logs. So: the gate's 360s cap getting hit under load is the **inferred** failure mechanism, consistent with these timings; treat it as the leading hypothesis for #92, not a proven root cause.

## Changes

- **`tests/helpers/integration-gate.ts`** — `describeIntegration` runs a suite only under `RUN_INTEGRATION=1`, else skips. Gated the CLI-subprocess / real-DB suites: `commands/{transcript,tags-metadata,tags-visualize,search-field-filter}`, `select-parameter`, `db/transcript`. (Two reasons, documented in the helper: temp-DB CLI e2e gated for wall time but still run on CI; live-DB suites self-skip on CI.)
- **Fixture conversion** of `db/transcript` → `tests/helpers/transcript-fixture.ts` builds the exact node graph the queries walk (SYS_A199 link, SYS_A252 speaker, metanode/tuple); `tests/db/transcript-fixture.test.ts` asserts concrete results + pure helpers. Covers the query logic via the LIKE path deterministically on CI; the FTS path stays in the integration-gated suite.
- **`package.json`** — `test` passes `--timeout 30000` (parity with CI). Intent: give per-test headroom so CPU-starvation-induced timeouts at the 5000ms default stop tripping under load. This raises the threshold — it does not prove the timeout-class is eliminated, and a genuinely hung test now takes 30s to fail. Added `test:integration`; `test:full` sets `RUN_INTEGRATION=1`.
- **CI `test.yml`** runs with `RUN_INTEGRATION=1` so the temp-DB CLI e2e suites keep their CI coverage.

## Result

Fast suite: 0 fail, ~28s at load 31 (vs ~57s before). This push passed the gate first try. I have not run a repeated-trials flake-rate measurement before/after.

## Remaining (tracked in #92)

`batch-operations`, `create-validation`, `node-builder`, `commands/helpers`, etc. implicitly resolve the real workspace DB through service internals (`batchCreateNodes`/`createNode` → `buildNodePayloadFromDatabase`) and catch `SQLITE_CANTOPEN` to skip on CI. Durable fix: inject a fixture DB into those services (DI). Left as follow-up to keep this PR focused.