### PR TITLE
test: finish #92 — remove the real-DB-via-service tail from the fast suite

### DIFF
--- a/src/mcp/tools/__tests__/field-values.test.ts
+++ b/src/mcp/tools/__tests__/field-values.test.ts
@@ -4,6 +4,7 @@
  */
 
 import { describe, it, expect } from "bun:test";
+import { describeIntegration } from "../../../../tests/helpers/integration-gate";
 import { existsSync } from "fs";
 import { fieldValues } from "../field-values";
 import { getDatabasePath } from "../../../config/paths";
@@ -12,7 +13,7 @@ import { getDatabasePath } from "../../../config/paths";
 const dbPath = getDatabasePath();
 const hasDatabase = existsSync(dbPath);
 
-describe("tana_field_values MCP Tool", () => {
+describeIntegration("tana_field_values MCP Tool", () => {
   // Skip integration tests if no database exists
   const testFn = hasDatabase ? it : it.skip;
 

--- a/src/mcp/tools/__tests__/field-values.test.ts
+++ b/src/mcp/tools/__tests__/field-values.test.ts
@@ -4,14 +4,15 @@
  */
 
 import { describe, it, expect } from "bun:test";
-import { describeIntegration } from "../../../../tests/helpers/integration-gate";
+import { describeIntegration, RUN_INTEGRATION } from "../../../../tests/helpers/integration-gate";
 import { existsSync } from "fs";
 import { fieldValues } from "../field-values";
 import { getDatabasePath } from "../../../config/paths";
 
-// Check if we have a database to test against
-const dbPath = getDatabasePath();
-const hasDatabase = existsSync(dbPath);
+// Resolve the workspace DB path only in integration mode, so importing this
+// file in the fast suite stays hermetic (the real-DB describe is gated anyway).
+const dbPath = RUN_INTEGRATION ? getDatabasePath() : "";
+const hasDatabase = RUN_INTEGRATION ? existsSync(dbPath) : false;
 
 describeIntegration("tana_field_values MCP Tool", () => {
   // Skip integration tests if no database exists

--- a/src/mcp/tools/__tests__/tools.test.ts
+++ b/src/mcp/tools/__tests__/tools.test.ts
@@ -6,6 +6,7 @@
  */
 
 import { describe, it, expect, beforeAll, afterAll } from 'bun:test';
+import { describeIntegration } from '../../../../tests/helpers/integration-gate';
 import { existsSync } from 'fs';
 import { Database } from 'bun:sqlite';
 import { stats } from '../stats';
@@ -21,7 +22,7 @@ import { getDatabasePath } from '../../../config/paths';
 const dbPath = getDatabasePath();
 const hasDatabase = existsSync(dbPath);
 
-describe('MCP Tools Integration', () => {
+describeIntegration('MCP Tools Integration', () => {
   // Skip all tests if no database exists
   const testFn = hasDatabase ? it : it.skip;
 

--- a/src/mcp/tools/__tests__/tools.test.ts
+++ b/src/mcp/tools/__tests__/tools.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { describe, it, expect, beforeAll, afterAll } from 'bun:test';
-import { describeIntegration } from '../../../../tests/helpers/integration-gate';
+import { describeIntegration, RUN_INTEGRATION } from '../../../../tests/helpers/integration-gate';
 import { existsSync } from 'fs';
 import { Database } from 'bun:sqlite';
 import { stats } from '../stats';
@@ -18,9 +18,10 @@ import { create } from '../create';
 import { sync } from '../sync';
 import { getDatabasePath } from '../../../config/paths';
 
-// Check if we have a database to test against
-const dbPath = getDatabasePath();
-const hasDatabase = existsSync(dbPath);
+// Resolve the workspace DB path only in integration mode, so importing this
+// file in the fast suite stays hermetic (the real-DB describe is gated anyway).
+const dbPath = RUN_INTEGRATION ? getDatabasePath() : '';
+const hasDatabase = RUN_INTEGRATION ? existsSync(dbPath) : false;
 
 describeIntegration('MCP Tools Integration', () => {
   // Skip all tests if no database exists

--- a/src/mcp/tools/__tests__/transcript.test.ts
+++ b/src/mcp/tools/__tests__/transcript.test.ts
@@ -5,6 +5,7 @@
  */
 
 import { describe, it, expect, beforeAll, afterAll } from "bun:test";
+import { describeIntegration } from "../../../../tests/helpers/integration-gate";
 import { Database } from "bun:sqlite";
 import { existsSync } from "fs";
 import { getDatabasePath, resolveWorkspace } from "../../../config/paths";
@@ -20,7 +21,7 @@ import {
   transcriptSearchSchema,
 } from "../../schemas";
 
-describe("MCP Transcript Tools", () => {
+describeIntegration("MCP Transcript Tools", () => {
   let hasTranscripts: boolean = false;
   let dbExists: boolean = false;
   let dbPath: string;

--- a/src/services/node-builder.test.ts
+++ b/src/services/node-builder.test.ts
@@ -16,6 +16,7 @@ import {
   createNode,
 } from './node-builder';
 import { getSchemaRegistry } from '../commands/schema';
+import { describeIntegration } from '../../tests/helpers/integration-gate';
 import { SCHEMA_CACHE_FILE } from '../config/paths';
 import { migrateSupertagMetadataSchema, migrateSchemaConsolidation } from '../db/migrate';
 import type { ChildNodeInput, CreateNodeInput } from '../types';
@@ -27,7 +28,7 @@ describe('Node Builder Service', () => {
   // =========================================================================
   // validateSupertags() Tests (1-3)
   // =========================================================================
-  describe('validateSupertags()', () => {
+  describeIntegration('validateSupertags()', () => {
     const testFn = hasSchema ? it : it.skip;
 
     // Test 1: Valid single tag
@@ -160,7 +161,7 @@ describe('Node Builder Service', () => {
   // =========================================================================
   // buildNodePayload() Tests (8-10)
   // =========================================================================
-  describe('buildNodePayload()', () => {
+  describeIntegration('buildNodePayload()', () => {
     const testFn = hasSchema ? it : it.skip;
 
     // Test 8: Basic node with supertag
@@ -262,7 +263,7 @@ describe('Node Builder Service', () => {
   // =========================================================================
   // createNode() Tests (11-12)
   // =========================================================================
-  describe('createNode()', () => {
+  describeIntegration('createNode()', () => {
     const testFn = hasSchema ? it : it.skip;
 
     // Test 11: Dry run mode returns payload
@@ -327,7 +328,7 @@ describe('Node Builder Service', () => {
   // =========================================================================
   // Database-backed createNode() Tests (T-1, T-3)
   // =========================================================================
-  describe('createNode() with database field types', () => {
+  describeIntegration('createNode() with database field types', () => {
     let testDir: string;
     let dbPath: string;
     let db: Database;

--- a/tests/batch-cli.test.ts
+++ b/tests/batch-cli.test.ts
@@ -15,7 +15,7 @@ import { Database } from 'bun:sqlite';
 import { mkdirSync, rmSync } from 'fs';
 import { join } from 'path';
 import { getUniqueTestDir } from './test-utils';
-import { createSeededDb, type SeededDb } from './helpers/seeded-db';
+import { withSeededDb } from './helpers/seeded-db';
 
 describe('createBatchCommand', () => {
   it('should create a command named "batch"', () => {
@@ -286,11 +286,9 @@ describe('batch create subcommand', () => {
 });
 
 describe('executeBatchCreate', () => {
-  // Inject a seeded DB so dry-run payload building doesn't resolve the real
-  // workspace DB (slow / CI-skip via SQLITE_CANTOPEN).
-  let seeded: SeededDb;
-  beforeEach(() => { seeded = createSeededDb('batch-cli-create'); });
-  afterEach(() => { seeded.cleanup(); });
+  // The DB-backed tests inject a seeded DB via withSeededDb so dry-run payload
+  // building doesn't resolve the real workspace DB (slow / CI-skip via
+  // SQLITE_CANTOPEN). The import-only test below needs no DB.
 
   it('should export executeBatchCreate function', async () => {
     const { executeBatchCreate } = await import('../src/commands/batch');
@@ -300,27 +298,31 @@ describe('executeBatchCreate', () => {
   it('should accept nodes array and return results', async () => {
     const { executeBatchCreate } = await import('../src/commands/batch');
 
-    const result = await executeBatchCreate([
-      { supertag: 'todo', name: 'Task 1' },
-      { supertag: 'todo', name: 'Task 2' },
-    ], { dryRun: true, _dbPath: seeded.dbPath });
+    await withSeededDb('batch-cli-create', async (dbPath) => {
+      const result = await executeBatchCreate([
+        { supertag: 'todo', name: 'Task 1' },
+        { supertag: 'todo', name: 'Task 2' },
+      ], { dryRun: true, _dbPath: dbPath });
 
-    expect(result).toHaveProperty('success');
-    expect(result).toHaveProperty('results');
-    expect(result).toHaveProperty('errors');
-    expect(result).toHaveProperty('dryRun', true);
+      expect(result).toHaveProperty('success');
+      expect(result).toHaveProperty('results');
+      expect(result).toHaveProperty('errors');
+      expect(result).toHaveProperty('dryRun', true);
+    });
   });
 
   it('should return errors for invalid nodes', async () => {
     const { executeBatchCreate } = await import('../src/commands/batch');
 
-    const result = await executeBatchCreate([
-      { supertag: 'todo', name: 'Valid' },
-      { supertag: '', name: 'Invalid - no supertag' },
-    ], { dryRun: true, _dbPath: seeded.dbPath });
+    await withSeededDb('batch-cli-create', async (dbPath) => {
+      const result = await executeBatchCreate([
+        { supertag: 'todo', name: 'Valid' },
+        { supertag: '', name: 'Invalid - no supertag' },
+      ], { dryRun: true, _dbPath: dbPath });
 
-    expect(result.success).toBe(false);
-    expect(result.errors.length).toBeGreaterThan(0);
+      expect(result.success).toBe(false);
+      expect(result.errors.length).toBeGreaterThan(0);
+    });
   });
 
   it('should read nodes from stdin content', async () => {
@@ -330,14 +332,16 @@ describe('executeBatchCreate', () => {
       { supertag: 'todo', name: 'Task from stdin' },
     ]);
 
-    const result = await executeBatchCreate([], {
-      dryRun: true,
-      stdin: true,
-      _stdinContent: stdinContent,
-      _dbPath: seeded.dbPath,
-    });
+    await withSeededDb('batch-cli-create', async (dbPath) => {
+      const result = await executeBatchCreate([], {
+        dryRun: true,
+        stdin: true,
+        _stdinContent: stdinContent,
+        _dbPath: dbPath,
+      });
 
-    expect(result.results.length).toBe(1);
+      expect(result.results.length).toBe(1);
+    });
   });
 });
 

--- a/tests/batch-cli.test.ts
+++ b/tests/batch-cli.test.ts
@@ -15,6 +15,7 @@ import { Database } from 'bun:sqlite';
 import { mkdirSync, rmSync } from 'fs';
 import { join } from 'path';
 import { getUniqueTestDir } from './test-utils';
+import { createSeededDb, type SeededDb } from './helpers/seeded-db';
 
 describe('createBatchCommand', () => {
   it('should create a command named "batch"', () => {
@@ -285,6 +286,12 @@ describe('batch create subcommand', () => {
 });
 
 describe('executeBatchCreate', () => {
+  // Inject a seeded DB so dry-run payload building doesn't resolve the real
+  // workspace DB (slow / CI-skip via SQLITE_CANTOPEN).
+  let seeded: SeededDb;
+  beforeEach(() => { seeded = createSeededDb('batch-cli-create'); });
+  afterEach(() => { seeded.cleanup(); });
+
   it('should export executeBatchCreate function', async () => {
     const { executeBatchCreate } = await import('../src/commands/batch');
     expect(typeof executeBatchCreate).toBe('function');
@@ -293,37 +300,27 @@ describe('executeBatchCreate', () => {
   it('should accept nodes array and return results', async () => {
     const { executeBatchCreate } = await import('../src/commands/batch');
 
-    try {
-      const result = await executeBatchCreate([
-        { supertag: 'todo', name: 'Task 1' },
-        { supertag: 'todo', name: 'Task 2' },
-      ], { dryRun: true });
+    const result = await executeBatchCreate([
+      { supertag: 'todo', name: 'Task 1' },
+      { supertag: 'todo', name: 'Task 2' },
+    ], { dryRun: true, _dbPath: seeded.dbPath });
 
-      expect(result).toHaveProperty('success');
-      expect(result).toHaveProperty('results');
-      expect(result).toHaveProperty('errors');
-      expect(result).toHaveProperty('dryRun', true);
-    } catch (e: any) {
-      if (e?.code === 'SQLITE_CANTOPEN') return; // No workspace database available
-      throw e;
-    }
+    expect(result).toHaveProperty('success');
+    expect(result).toHaveProperty('results');
+    expect(result).toHaveProperty('errors');
+    expect(result).toHaveProperty('dryRun', true);
   });
 
   it('should return errors for invalid nodes', async () => {
     const { executeBatchCreate } = await import('../src/commands/batch');
 
-    try {
-      const result = await executeBatchCreate([
-        { supertag: 'todo', name: 'Valid' },
-        { supertag: '', name: 'Invalid - no supertag' },
-      ], { dryRun: true });
+    const result = await executeBatchCreate([
+      { supertag: 'todo', name: 'Valid' },
+      { supertag: '', name: 'Invalid - no supertag' },
+    ], { dryRun: true, _dbPath: seeded.dbPath });
 
-      expect(result.success).toBe(false);
-      expect(result.errors.length).toBeGreaterThan(0);
-    } catch (e: any) {
-      if (e?.code === 'SQLITE_CANTOPEN') return;
-      throw e;
-    }
+    expect(result.success).toBe(false);
+    expect(result.errors.length).toBeGreaterThan(0);
   });
 
   it('should read nodes from stdin content', async () => {
@@ -333,18 +330,14 @@ describe('executeBatchCreate', () => {
       { supertag: 'todo', name: 'Task from stdin' },
     ]);
 
-    try {
-      const result = await executeBatchCreate([], {
-        dryRun: true,
-        stdin: true,
-        _stdinContent: stdinContent,
-      });
+    const result = await executeBatchCreate([], {
+      dryRun: true,
+      stdin: true,
+      _stdinContent: stdinContent,
+      _dbPath: seeded.dbPath,
+    });
 
-      expect(result.results.length).toBe(1);
-    } catch (e: any) {
-      if (e?.code === 'SQLITE_CANTOPEN') return;
-      throw e;
-    }
+    expect(result.results.length).toBe(1);
   });
 });
 

--- a/tests/batch-operations.test.ts
+++ b/tests/batch-operations.test.ts
@@ -10,7 +10,7 @@ import { Database } from 'bun:sqlite';
 import { mkdirSync, rmSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
-import { createSeededDb } from './helpers/seeded-db';
+import { withSeededDb } from './helpers/seeded-db';
 
 // T-1.1: Test that types and service skeleton exist
 describe('batch-operations types', () => {
@@ -529,46 +529,37 @@ describe('batchCreateNodes validation', () => {
       name: `Task ${i}`,
     }));
 
-    const seeded = createSeededDb('batch-validation');
-    try {
-      const result = await batchCreateNodes(maxNodes, { dryRun: true, _dbPathOverride: seeded.dbPath });
+    await withSeededDb('batch-validation', async (dbPath) => {
+      const result = await batchCreateNodes(maxNodes, { dryRun: true, _dbPathOverride: dbPath });
       expect(result).toBeDefined();
       expect(result).toHaveLength(BATCH_CREATE_MAX_NODES);
-    } finally {
-      seeded.cleanup();
-    }
+    });
   });
 
   it('should validate node structure: supertag required', async () => {
     const { batchCreateNodes } = await import('../src/services/batch-operations');
 
-    const seeded = createSeededDb('batch-validation');
-    try {
+    await withSeededDb('batch-validation', async (dbPath) => {
       const results = await batchCreateNodes([
         { supertag: '', name: 'No tag' },
-      ] as any, { dryRun: true, _dbPathOverride: seeded.dbPath });
+      ] as any, { dryRun: true, _dbPathOverride: dbPath });
 
       expect(results[0].error).toBeDefined();
       expect(results[0].error).toContain('supertag');
-    } finally {
-      seeded.cleanup();
-    }
+    });
   });
 
   it('should validate node structure: name required', async () => {
     const { batchCreateNodes } = await import('../src/services/batch-operations');
 
-    const seeded = createSeededDb('batch-validation');
-    try {
+    await withSeededDb('batch-validation', async (dbPath) => {
       const results = await batchCreateNodes([
         { supertag: 'todo', name: '' },
-      ], { dryRun: true, _dbPathOverride: seeded.dbPath });
+      ], { dryRun: true, _dbPathOverride: dbPath });
 
       expect(results[0].error).toBeDefined();
       expect(results[0].error).toContain('name');
-    } finally {
-      seeded.cleanup();
-    }
+    });
   });
 
   it('should include suggestion in validation error', async () => {

--- a/tests/batch-operations.test.ts
+++ b/tests/batch-operations.test.ts
@@ -10,6 +10,7 @@ import { Database } from 'bun:sqlite';
 import { mkdirSync, rmSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
+import { createSeededDb, type SeededDb } from './helpers/seeded-db';
 
 // T-1.1: Test that types and service skeleton exist
 describe('batch-operations types', () => {
@@ -492,6 +493,12 @@ describe('batchCreateNodes', () => {
 // =============================================================================
 
 describe('batchCreateNodes validation', () => {
+  // Inject a seeded DB so the tests that get past size validation and into
+  // payload-building don't resolve the real workspace DB (slow / CI-skip).
+  let seeded: SeededDb;
+  beforeEach(() => { seeded = createSeededDb('batch-validation'); });
+  afterEach(() => { seeded.cleanup(); });
+
   it('should throw VALIDATION_ERROR when more than 50 nodes provided', async () => {
     const { batchCreateNodes, BATCH_CREATE_MAX_NODES } = await import(
       '../src/services/batch-operations'
@@ -523,45 +530,31 @@ describe('batchCreateNodes validation', () => {
       name: `Task ${i}`,
     }));
 
-    try {
-      const result = await batchCreateNodes(maxNodes, { dryRun: true });
-      expect(result).toBeDefined();
-    } catch (e: any) {
-      if (e?.code === 'SQLITE_CANTOPEN') return; // No workspace database available
-      throw e;
-    }
+    const result = await batchCreateNodes(maxNodes, { dryRun: true, _dbPathOverride: seeded.dbPath });
+    expect(result).toBeDefined();
+    expect(result).toHaveLength(BATCH_CREATE_MAX_NODES);
   });
 
   it('should validate node structure: supertag required', async () => {
     const { batchCreateNodes } = await import('../src/services/batch-operations');
 
-    try {
-      const results = await batchCreateNodes([
-        { supertag: '', name: 'No tag' },
-      ] as any, { dryRun: true });
+    const results = await batchCreateNodes([
+      { supertag: '', name: 'No tag' },
+    ] as any, { dryRun: true, _dbPathOverride: seeded.dbPath });
 
-      expect(results[0].error).toBeDefined();
-      expect(results[0].error).toContain('supertag');
-    } catch (e: any) {
-      if (e?.code === 'SQLITE_CANTOPEN') return;
-      throw e;
-    }
+    expect(results[0].error).toBeDefined();
+    expect(results[0].error).toContain('supertag');
   });
 
   it('should validate node structure: name required', async () => {
     const { batchCreateNodes } = await import('../src/services/batch-operations');
 
-    try {
-      const results = await batchCreateNodes([
-        { supertag: 'todo', name: '' },
-      ], { dryRun: true });
+    const results = await batchCreateNodes([
+      { supertag: 'todo', name: '' },
+    ], { dryRun: true, _dbPathOverride: seeded.dbPath });
 
-      expect(results[0].error).toBeDefined();
-      expect(results[0].error).toContain('name');
-    } catch (e: any) {
-      if (e?.code === 'SQLITE_CANTOPEN') return;
-      throw e;
-    }
+    expect(results[0].error).toBeDefined();
+    expect(results[0].error).toContain('name');
   });
 
   it('should include suggestion in validation error', async () => {

--- a/tests/batch-operations.test.ts
+++ b/tests/batch-operations.test.ts
@@ -10,7 +10,7 @@ import { Database } from 'bun:sqlite';
 import { mkdirSync, rmSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
-import { createSeededDb, type SeededDb } from './helpers/seeded-db';
+import { createSeededDb } from './helpers/seeded-db';
 
 // T-1.1: Test that types and service skeleton exist
 describe('batch-operations types', () => {
@@ -493,11 +493,10 @@ describe('batchCreateNodes', () => {
 // =============================================================================
 
 describe('batchCreateNodes validation', () => {
-  // Inject a seeded DB so the tests that get past size validation and into
-  // payload-building don't resolve the real workspace DB (slow / CI-skip).
-  let seeded: SeededDb;
-  beforeEach(() => { seeded = createSeededDb('batch-validation'); });
-  afterEach(() => { seeded.cleanup(); });
+  // Only the tests that get past size validation into payload-building need a
+  // DB; they create a seeded one inline (the throw-before-DB cases don't pay
+  // for it). Injected via _dbPathOverride so they never resolve the real
+  // workspace DB (slow / CI-skip).
 
   it('should throw VALIDATION_ERROR when more than 50 nodes provided', async () => {
     const { batchCreateNodes, BATCH_CREATE_MAX_NODES } = await import(
@@ -530,31 +529,46 @@ describe('batchCreateNodes validation', () => {
       name: `Task ${i}`,
     }));
 
-    const result = await batchCreateNodes(maxNodes, { dryRun: true, _dbPathOverride: seeded.dbPath });
-    expect(result).toBeDefined();
-    expect(result).toHaveLength(BATCH_CREATE_MAX_NODES);
+    const seeded = createSeededDb('batch-validation');
+    try {
+      const result = await batchCreateNodes(maxNodes, { dryRun: true, _dbPathOverride: seeded.dbPath });
+      expect(result).toBeDefined();
+      expect(result).toHaveLength(BATCH_CREATE_MAX_NODES);
+    } finally {
+      seeded.cleanup();
+    }
   });
 
   it('should validate node structure: supertag required', async () => {
     const { batchCreateNodes } = await import('../src/services/batch-operations');
 
-    const results = await batchCreateNodes([
-      { supertag: '', name: 'No tag' },
-    ] as any, { dryRun: true, _dbPathOverride: seeded.dbPath });
+    const seeded = createSeededDb('batch-validation');
+    try {
+      const results = await batchCreateNodes([
+        { supertag: '', name: 'No tag' },
+      ] as any, { dryRun: true, _dbPathOverride: seeded.dbPath });
 
-    expect(results[0].error).toBeDefined();
-    expect(results[0].error).toContain('supertag');
+      expect(results[0].error).toBeDefined();
+      expect(results[0].error).toContain('supertag');
+    } finally {
+      seeded.cleanup();
+    }
   });
 
   it('should validate node structure: name required', async () => {
     const { batchCreateNodes } = await import('../src/services/batch-operations');
 
-    const results = await batchCreateNodes([
-      { supertag: 'todo', name: '' },
-    ], { dryRun: true, _dbPathOverride: seeded.dbPath });
+    const seeded = createSeededDb('batch-validation');
+    try {
+      const results = await batchCreateNodes([
+        { supertag: 'todo', name: '' },
+      ], { dryRun: true, _dbPathOverride: seeded.dbPath });
 
-    expect(results[0].error).toBeDefined();
-    expect(results[0].error).toContain('name');
+      expect(results[0].error).toBeDefined();
+      expect(results[0].error).toContain('name');
+    } finally {
+      seeded.cleanup();
+    }
   });
 
   it('should include suggestion in validation error', async () => {

--- a/tests/commands/create-validation.test.ts
+++ b/tests/commands/create-validation.test.ts
@@ -9,11 +9,12 @@
  */
 
 import { describe, it, expect, beforeAll, afterAll } from "bun:test";
+import { describeIntegration } from "../helpers/integration-gate";
 import { $ } from "bun";
 import { mkdirSync, writeFileSync, rmSync, existsSync } from "fs";
 import { join } from "path";
 
-describe("Create Command Field Validation", () => {
+describeIntegration("Create Command Field Validation", () => {
   const testDir = join(process.cwd(), "tmp-test-create-validation");
   const configDir = join(testDir, "config", "supertag");
   const dataDir = join(testDir, "data", "supertag", "workspaces", "main");

--- a/tests/commands/fields.test.ts
+++ b/tests/commands/fields.test.ts
@@ -8,6 +8,7 @@
  */
 
 import { describe, it, expect, beforeAll, afterAll } from "bun:test";
+import { describeIntegration } from "../helpers/integration-gate";
 import { Database } from "bun:sqlite";
 import { existsSync, mkdirSync, rmSync } from "fs";
 import { join } from "path";
@@ -196,7 +197,7 @@ describe("Fields CLI Commands", () => {
     });
   });
 
-  describe("Integration Tests (with real database)", () => {
+  describeIntegration("Integration Tests (with real database)", () => {
     // These tests require a real database with indexed field values
     // Skip if no database exists or if it's locked by other tests
     const realDbPath =

--- a/tests/helpers/seeded-db.ts
+++ b/tests/helpers/seeded-db.ts
@@ -8,13 +8,21 @@
  * `buildNodePayloadFromDatabase(db.dbPath, …)` — so the test is deterministic
  * and runs on CI instead of depending on a real workspace database.
  *
- * Schema mirrors the columns the node-builder / schema-service read; it seeds a
- * couple of supertags (`todo`, `meeting`) so tag resolution succeeds.
+ * The supertag tables the schema-service reads (`supertag_metadata`,
+ * `supertag_fields`, …) are built with the PRODUCTION migration functions so
+ * the fixture can't drift from the real schema. Only the two indexer-owned
+ * tables the builder may touch (`nodes`, `tag_applications`) are declared here,
+ * matching `src/db/indexer.ts`. Seeds `todo`/`meeting` so tag resolution works.
  */
 import { Database } from "bun:sqlite";
 import { mkdirSync, rmSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
+import {
+  migrateSupertagMetadataSchema,
+  migrateSchemaConsolidation,
+  migrateFieldValuesSchema,
+} from "../../src/db/migrate";
 
 export interface SeededDb {
   /** Absolute path to the seeded SQLite database. */
@@ -34,72 +42,29 @@ export function createSeededDb(label = "seeded"): SeededDb {
   const dbPath = join(dir, "test.db");
 
   const db = new Database(dbPath);
+
+  // Schema-service tables via the real production migrations (no drift).
+  migrateSupertagMetadataSchema(db);
+  migrateSchemaConsolidation(db);
+  migrateFieldValuesSchema(db);
+
+  // Indexer-owned tables the node builder may read (mirror src/db/indexer.ts).
   db.run(`
-    CREATE TABLE nodes (
+    CREATE TABLE IF NOT EXISTS nodes (
       id TEXT PRIMARY KEY,
       name TEXT,
       parent_id TEXT,
-      node_type TEXT,
       created INTEGER,
       updated INTEGER,
       raw_data TEXT
     )
   `);
   db.run(`
-    CREATE TABLE supertags (
-      id TEXT PRIMARY KEY,
-      name TEXT,
-      color TEXT
-    )
-  `);
-  db.run(`
-    CREATE TABLE tag_applications (
-      tag_node_id TEXT,
-      data_node_id TEXT,
-      tag_name TEXT,
-      PRIMARY KEY (tag_node_id, data_node_id)
-    )
-  `);
-  db.run(`
-    CREATE TABLE field_definitions (
-      id TEXT PRIMARY KEY,
-      supertag_id TEXT,
-      name TEXT,
-      field_type TEXT
-    )
-  `);
-  db.run(`
-    CREATE TABLE supertag_metadata (
-      id INTEGER PRIMARY KEY AUTOINCREMENT,
-      tag_id TEXT NOT NULL UNIQUE,
-      tag_name TEXT NOT NULL,
-      normalized_name TEXT NOT NULL,
-      description TEXT,
-      color TEXT,
-      created_at INTEGER
-    )
-  `);
-  db.run(`
-    CREATE TABLE supertag_fields (
-      tag_id TEXT NOT NULL,
-      field_name TEXT NOT NULL,
-      field_label_id TEXT NOT NULL,
-      field_order INTEGER DEFAULT 0,
-      normalized_name TEXT,
-      description TEXT,
-      inferred_data_type TEXT,
-      target_supertag_id TEXT,
-      target_supertag_name TEXT,
-      default_value_id TEXT,
-      default_value_text TEXT,
-      PRIMARY KEY (tag_id, field_label_id)
-    )
-  `);
-  db.run(`
-    CREATE TABLE supertag_parents (
-      child_tag_id TEXT NOT NULL,
-      parent_tag_id TEXT NOT NULL,
-      PRIMARY KEY (child_tag_id, parent_tag_id)
+    CREATE TABLE IF NOT EXISTS tag_applications (
+      tuple_node_id TEXT NOT NULL,
+      data_node_id TEXT NOT NULL,
+      tag_id TEXT,
+      tag_name TEXT
     )
   `);
 
@@ -107,7 +72,6 @@ export function createSeededDb(label = "seeded"): SeededDb {
     ["tag_todo", "todo", "#FF0000"],
     ["tag_meeting", "meeting", "#00FF00"],
   ] as const) {
-    db.run(`INSERT INTO supertags (id, name, color) VALUES (?, ?, ?)`, [id, name, color]);
     db.run(
       `INSERT INTO supertag_metadata (tag_id, tag_name, normalized_name, color) VALUES (?, ?, ?, ?)`,
       [id, name, name, color]

--- a/tests/helpers/seeded-db.ts
+++ b/tests/helpers/seeded-db.ts
@@ -1,0 +1,123 @@
+/**
+ * Shared seeded test database for service-level tests that would otherwise
+ * implicitly resolve the live 854k-node workspace DB (and then either run for
+ * tens of seconds or `SQLITE_CANTOPEN`-skip on CI).
+ *
+ * Pass `dbPath` to a service via its injection point — e.g.
+ * `batchCreateNodes(nodes, { dryRun: true, _dbPathOverride: db.dbPath })` or
+ * `buildNodePayloadFromDatabase(db.dbPath, …)` — so the test is deterministic
+ * and runs on CI instead of depending on a real workspace database.
+ *
+ * Schema mirrors the columns the node-builder / schema-service read; it seeds a
+ * couple of supertags (`todo`, `meeting`) so tag resolution succeeds.
+ */
+import { Database } from "bun:sqlite";
+import { mkdirSync, rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+
+export interface SeededDb {
+  /** Absolute path to the seeded SQLite database. */
+  dbPath: string;
+  /** Remove the temp directory. Call in afterEach/afterAll. */
+  cleanup: () => void;
+}
+
+let counter = 0;
+
+/**
+ * Create a fresh, schema-valid, seeded database in a unique temp directory.
+ */
+export function createSeededDb(label = "seeded"): SeededDb {
+  const dir = join(tmpdir(), `supertag-${label}-${process.pid}-${counter++}`);
+  mkdirSync(dir, { recursive: true });
+  const dbPath = join(dir, "test.db");
+
+  const db = new Database(dbPath);
+  db.run(`
+    CREATE TABLE nodes (
+      id TEXT PRIMARY KEY,
+      name TEXT,
+      parent_id TEXT,
+      node_type TEXT,
+      created INTEGER,
+      updated INTEGER,
+      raw_data TEXT
+    )
+  `);
+  db.run(`
+    CREATE TABLE supertags (
+      id TEXT PRIMARY KEY,
+      name TEXT,
+      color TEXT
+    )
+  `);
+  db.run(`
+    CREATE TABLE tag_applications (
+      tag_node_id TEXT,
+      data_node_id TEXT,
+      tag_name TEXT,
+      PRIMARY KEY (tag_node_id, data_node_id)
+    )
+  `);
+  db.run(`
+    CREATE TABLE field_definitions (
+      id TEXT PRIMARY KEY,
+      supertag_id TEXT,
+      name TEXT,
+      field_type TEXT
+    )
+  `);
+  db.run(`
+    CREATE TABLE supertag_metadata (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      tag_id TEXT NOT NULL UNIQUE,
+      tag_name TEXT NOT NULL,
+      normalized_name TEXT NOT NULL,
+      description TEXT,
+      color TEXT,
+      created_at INTEGER
+    )
+  `);
+  db.run(`
+    CREATE TABLE supertag_fields (
+      tag_id TEXT NOT NULL,
+      field_name TEXT NOT NULL,
+      field_label_id TEXT NOT NULL,
+      field_order INTEGER DEFAULT 0,
+      normalized_name TEXT,
+      description TEXT,
+      inferred_data_type TEXT,
+      target_supertag_id TEXT,
+      target_supertag_name TEXT,
+      default_value_id TEXT,
+      default_value_text TEXT,
+      PRIMARY KEY (tag_id, field_label_id)
+    )
+  `);
+  db.run(`
+    CREATE TABLE supertag_parents (
+      child_tag_id TEXT NOT NULL,
+      parent_tag_id TEXT NOT NULL,
+      PRIMARY KEY (child_tag_id, parent_tag_id)
+    )
+  `);
+
+  for (const [id, name, color] of [
+    ["tag_todo", "todo", "#FF0000"],
+    ["tag_meeting", "meeting", "#00FF00"],
+  ] as const) {
+    db.run(`INSERT INTO supertags (id, name, color) VALUES (?, ?, ?)`, [id, name, color]);
+    db.run(
+      `INSERT INTO supertag_metadata (tag_id, tag_name, normalized_name, color) VALUES (?, ?, ?, ?)`,
+      [id, name, name, color]
+    );
+  }
+
+  db.close();
+
+  return {
+    dbPath,
+    cleanup: () => rmSync(dir, { recursive: true, force: true }),
+  };
+}

--- a/tests/helpers/seeded-db.ts
+++ b/tests/helpers/seeded-db.ts
@@ -10,9 +10,10 @@
  *
  * The supertag tables the schema-service reads (`supertag_metadata`,
  * `supertag_fields`, …) are built with the PRODUCTION migration functions so
- * the fixture can't drift from the real schema. Only the two indexer-owned
- * tables the builder may touch (`nodes`, `tag_applications`) are declared here,
- * matching `src/db/indexer.ts`. Seeds `todo`/`meeting` so tag resolution works.
+ * the fixture can't drift from the real schema. The two indexer-owned tables
+ * (`nodes`, `tag_applications`) are declared here as a minimal local subset —
+ * not a verified mirror of `src/db/indexer.ts`; they exist only so the builder
+ * can open the DB without `SQLITE_CANTOPEN`. Seeds `todo`/`meeting`.
  */
 import { Database } from "bun:sqlite";
 import { mkdirSync, rmSync } from "fs";
@@ -84,4 +85,21 @@ export function createSeededDb(label = "seeded"): SeededDb {
     dbPath,
     cleanup: () => rmSync(dir, { recursive: true, force: true }),
   };
+}
+
+/**
+ * Run `fn` with a fresh seeded database path, guaranteeing cleanup afterwards.
+ * Use in the individual tests that need a DB so throw-before-DB / import-only
+ * tests in the same describe don't pay for fixture setup.
+ */
+export async function withSeededDb<T>(
+  label: string,
+  fn: (dbPath: string) => Promise<T>
+): Promise<T> {
+  const seeded = createSeededDb(label);
+  try {
+    return await fn(seeded.dbPath);
+  } finally {
+    seeded.cleanup();
+  }
 }


### PR DESCRIPTION
Follow-up to #95 — finishes #92. Removes the remaining tests that implicitly resolved the live 854k-node workspace DB through service internals, so the fast pre-push suite is hermetic and load-immune.

## DI-converted (kept on CI, deterministic)

- **`tests/helpers/seeded-db.ts`** — shared seeded DB. The supertag tables the schema-service reads are built via the **production migrations** (`migrateSupertagMetadataSchema`/`migrateSchemaConsolidation`/`migrateFieldValuesSchema`) so the fixture can't drift; only the two indexer-owned tables (`nodes`, `tag_applications`) are declared locally. Seeds `todo`/`meeting`.
- **`batch-operations.test.ts`** `validation` describe — the three payload-building tests create + clean up a seeded DB inline and pass `_dbPathOverride` (the 18s "exactly 50 nodes" boundary test now runs in ~ms); the two throw-before-DB cases build nothing.
- **`batch-cli.test.ts`** `executeBatchCreate` describe — inject `_dbPath` likewise.

## Gated behind `RUN_INTEGRATION` (run on CI + `test:integration`; self-skip on CI with no DB)

- `commands/create-validation.test.ts` (CLI-subprocess validation)
- `commands/fields.test.ts` — only the "Integration Tests (with real database)" describe; the `TEST_DB`-backed unit describes stay fast.
- `mcp/tools/__tests__/transcript.test.ts`, `tools.test.ts` ("MCP Tools Integration" only — sibling "MCP Tools Unit Tests" stays), `field-values.test.ts`. In these last two, the module-level `getDatabasePath()`/`existsSync` are guarded behind the gate's `RUN_INTEGRATION` flag, so importing them in the fast suite does **not** resolve the workspace DB.
- `services/node-builder.test.ts` — the four `getSchemaRegistry`/`createNode` describes; `buildChildNodes` (hermetic) stays fast.

## Result

Fast suite: **0 fail, 55s at load 133** (before this work it blew past the pre-push hook's 360s cap at load ~60). No fast-suite test resolves the workspace DB any more — the real-DB suites are gated and their path-resolution is `RUN_INTEGRATION`-guarded.

DI was preferred where the service exposed an injection point (`_dbPathOverride`/`_dbPath`) so coverage stays on CI; gating was used for CLI-subprocess and registry/real-DB suites where a faithful fixture is disproportionate.

Closes #92.