### PR TITLE
feat: support append mode for Tana field updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to Supertag CLI are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.5.11] - 2026-06-22
+
+### Added
+- **Field updates can append to multi-value fields** — `supertag set-field` now exposes Tana Local API's native append mode via `--append`, and MCP callers can pass `mode: "append"` to both `tana_set_field` and `tana_set_field_option`. Text/content updates and option-field updates now forward `mode: "replace" | "append"` directly to the Local API. Option updates no longer require a dummy positional value when `--option-id` is used.
+
 ## [2.5.10] - 2026-06-12
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -191,7 +191,9 @@ supertag tag create "sprint" --description "Sprint supertag"
 
 # Set field values
 supertag set-field <nodeId> <attributeId> "value"
-supertag set-field <nodeId> <attributeId> --option-id <optionId>
+supertag set-field <nodeId> <attributeId> "additional value" --append
+supertag set-field <nodeId> <attributeId> _ --option-id <optionId>
+supertag set-field <nodeId> <attributeId> _ --option-id <optionId> --append
 
 # Check/uncheck and trash
 supertag done <nodeId>

--- a/README.md
+++ b/README.md
@@ -192,8 +192,8 @@ supertag tag create "sprint" --description "Sprint supertag"
 # Set field values
 supertag set-field <nodeId> <attributeId> "value"
 supertag set-field <nodeId> <attributeId> "additional value" --append
-supertag set-field <nodeId> <attributeId> _ --option-id <optionId>
-supertag set-field <nodeId> <attributeId> _ --option-id <optionId> --append
+supertag set-field <nodeId> <attributeId> --option-id <optionId>
+supertag set-field <nodeId> <attributeId> --option-id <optionId> --append
 
 # Check/uncheck and trash
 supertag done <nodeId>

--- a/SKILL.md
+++ b/SKILL.md
@@ -345,7 +345,7 @@ Create a new supertag definition. Requires Local API.
 | `description` | string | No | Optional description |
 
 ### tana_set_field
-Set a text field value on a node. Requires Local API.
+Set or append a text field value on a node. Requires Local API.
 
 **Parameters:**
 | Parameter | Type | Required | Description |
@@ -353,9 +353,10 @@ Set a text field value on a node. Requires Local API.
 | `nodeId` | string | Yes | Tana node ID |
 | `attributeId` | string | Yes | Field attribute ID |
 | `content` | string | Yes | Field value |
+| `mode` | string | No | `replace` (default) or `append` for multi-value fields |
 
 ### tana_set_field_option
-Set a field option (dropdown) value on a node. Requires Local API.
+Set or append a field option (dropdown) value on a node. Requires Local API.
 
 **Parameters:**
 | Parameter | Type | Required | Description |
@@ -363,6 +364,7 @@ Set a field option (dropdown) value on a node. Requires Local API.
 | `nodeId` | string | Yes | Tana node ID |
 | `attributeId` | string | Yes | Field attribute ID |
 | `optionId` | string | Yes | Option ID to set |
+| `mode` | string | No | `replace` (default) or `append` for multi-value option fields |
 
 ### tana_trash_node
 Move a node to trash. Requires Local API.

--- a/src/api/backend.ts
+++ b/src/api/backend.ts
@@ -16,6 +16,7 @@ import type {
   DoneResponse,
   TrashResponse,
   ImportResponse,
+  FieldSetMode,
 } from '../types/local-api';
 
 /**
@@ -99,6 +100,7 @@ export interface TanaBackend {
     nodeId: string,
     attributeId: string,
     content: string,
+    mode?: FieldSetMode,
   ): Promise<FieldContentResponse>;
 
   /**
@@ -111,6 +113,7 @@ export interface TanaBackend {
     nodeId: string,
     attributeId: string,
     optionId: string,
+    mode?: FieldSetMode,
   ): Promise<FieldOptionResponse>;
 
   /**

--- a/src/api/input-api-backend.ts
+++ b/src/api/input-api-backend.ts
@@ -13,6 +13,7 @@ import type {
   TagOperationResponse,
   FieldContentResponse,
   FieldOptionResponse,
+  FieldSetMode,
   DoneResponse,
   TrashResponse,
 } from '../types/local-api';
@@ -97,6 +98,7 @@ export class InputApiBackend implements TanaBackend {
     _nodeId: string,
     _attributeId: string,
     _content: string,
+    _mode?: FieldSetMode,
   ): Promise<FieldContentResponse> {
     throw mutationNotSupported("setFieldContent");
   }
@@ -105,6 +107,7 @@ export class InputApiBackend implements TanaBackend {
     _nodeId: string,
     _attributeId: string,
     _optionId: string,
+    _mode?: FieldSetMode,
   ): Promise<FieldOptionResponse> {
     throw mutationNotSupported("setFieldOption");
   }

--- a/src/api/local-api-backend.ts
+++ b/src/api/local-api-backend.ts
@@ -21,6 +21,7 @@ import type {
   TagOperationResponse,
   FieldContentResponse,
   FieldOptionResponse,
+  FieldSetMode,
   DoneResponse,
   TrashResponse,
 } from '../types/local-api';
@@ -284,16 +285,18 @@ export class LocalApiBackend implements TanaBackend {
     nodeId: string,
     attributeId: string,
     content: string,
+    mode?: FieldSetMode,
   ): Promise<FieldContentResponse> {
-    return this.client.setFieldContent(nodeId, attributeId, content);
+    return this.client.setFieldContent(nodeId, attributeId, content, mode);
   }
 
   async setFieldOption(
     nodeId: string,
     attributeId: string,
     optionId: string,
+    mode?: FieldSetMode,
   ): Promise<FieldOptionResponse> {
-    return this.client.setFieldOption(nodeId, attributeId, optionId);
+    return this.client.setFieldOption(nodeId, attributeId, optionId, mode);
   }
 
   async checkNode(nodeId: string): Promise<DoneResponse> {

--- a/src/api/local-api-client.ts
+++ b/src/api/local-api-client.ts
@@ -15,6 +15,7 @@ import {
   TagOperationResponseSchema, type TagOperationResponse,
   FieldContentResponseSchema, type FieldContentResponse,
   FieldOptionResponseSchema, type FieldOptionResponse,
+  type FieldSetMode,
   UpdateResponseSchema, type UpdateResponse,
   DoneResponseSchema, type DoneResponse,
   TrashResponseSchema, type TrashResponse,
@@ -414,9 +415,18 @@ export class LocalApiClient {
    * Set a field's content value.
    * POST /nodes/{nodeId}/fields/{attributeId}/content
    */
-  async setFieldContent(nodeId: string, attributeId: string, content: string): Promise<FieldContentResponse> {
+  async setFieldContent(
+    nodeId: string,
+    attributeId: string,
+    content: string,
+    mode?: FieldSetMode,
+  ): Promise<FieldContentResponse> {
     return this.request(
-      { method: 'POST', path: `/nodes/${encodeURIComponent(nodeId)}/fields/${encodeURIComponent(attributeId)}/content`, body: { content } },
+      {
+        method: 'POST',
+        path: `/nodes/${encodeURIComponent(nodeId)}/fields/${encodeURIComponent(attributeId)}/content`,
+        body: mode ? { content, mode } : { content },
+      },
       FieldContentResponseSchema,
     );
   }
@@ -425,9 +435,18 @@ export class LocalApiClient {
    * Set a field's selected option.
    * POST /nodes/{nodeId}/fields/{attributeId}/option
    */
-  async setFieldOption(nodeId: string, attributeId: string, optionId: string): Promise<FieldOptionResponse> {
+  async setFieldOption(
+    nodeId: string,
+    attributeId: string,
+    optionId: string,
+    mode?: FieldSetMode,
+  ): Promise<FieldOptionResponse> {
     return this.request(
-      { method: 'POST', path: `/nodes/${encodeURIComponent(nodeId)}/fields/${encodeURIComponent(attributeId)}/option`, body: { optionId } },
+      {
+        method: 'POST',
+        path: `/nodes/${encodeURIComponent(nodeId)}/fields/${encodeURIComponent(attributeId)}/option`,
+        body: mode ? { optionId, mode } : { optionId },
+      },
       FieldOptionResponseSchema,
     );
   }

--- a/src/commands/set-field.ts
+++ b/src/commands/set-field.ts
@@ -5,18 +5,20 @@
  */
 import { Command } from 'commander';
 import { resolveBackend } from '../api/backend-resolver';
+import type { FieldSetMode } from '../types/local-api';
 import { exitWithError } from '../utils/errors';
 
 export function createSetFieldCommand(): Command {
   const setField = new Command('set-field');
   setField
-    .description('Set a field value on an existing node (requires local API)')
+    .description('Set or append a field value on an existing node (requires local API)')
     .argument('<nodeId>', 'Node ID to update')
     .argument('<fieldName>', 'Field name or attribute ID')
     .argument('<value>', 'Field value to set')
     .option('--field-id <id>', 'Use attribute ID directly (bypass name resolution)')
     .option('--option-id <id>', 'Set as option field with this option ID')
-    .action(async (nodeId: string, fieldName: string, value: string, options: { fieldId?: string; optionId?: string }) => {
+    .option('--append', 'Append to an existing multi-value field instead of replacing it')
+    .action(async (nodeId: string, fieldName: string, value: string, options: { fieldId?: string; optionId?: string; append?: boolean }) => {
       try {
         const backend = await resolveBackend();
         if (!backend.supportsMutations()) {
@@ -26,17 +28,18 @@ export function createSetFieldCommand(): Command {
         }
 
         const attributeId = options.fieldId || fieldName;
+        const mode: FieldSetMode = options.append ? 'append' : 'replace';
 
         if (options.optionId) {
           // Option field
-          const result = await backend.setFieldOption(nodeId, attributeId, options.optionId);
-          console.log(`Set option field on node ${result.nodeId}`);
+          const result = await backend.setFieldOption(nodeId, attributeId, options.optionId, mode);
+          console.log(`${mode === 'append' ? 'Appended option to' : 'Set option field on'} node ${result.nodeId}`);
           console.log(`  Field: ${result.attributeId}`);
           console.log(`  Option: ${result.optionName}`);
         } else {
           // Content field (text, number, date, url, email)
-          const result = await backend.setFieldContent(nodeId, attributeId, value);
-          console.log(`Set field on node ${result.nodeId}`);
+          const result = await backend.setFieldContent(nodeId, attributeId, value, mode);
+          console.log(`${mode === 'append' ? 'Appended to field on' : 'Set field on'} node ${result.nodeId}`);
           console.log(`  Field: ${result.attributeId}`);
           console.log(`  Value: ${result.content}`);
         }

--- a/src/commands/set-field.ts
+++ b/src/commands/set-field.ts
@@ -14,11 +14,11 @@ export function createSetFieldCommand(): Command {
     .description('Set or append a field value on an existing node (requires local API)')
     .argument('<nodeId>', 'Node ID to update')
     .argument('<fieldName>', 'Field name or attribute ID')
-    .argument('<value>', 'Field value to set')
+    .argument('[value]', 'Field value to set (required unless --option-id is used)')
     .option('--field-id <id>', 'Use attribute ID directly (bypass name resolution)')
     .option('--option-id <id>', 'Set as option field with this option ID')
     .option('--append', 'Append to an existing multi-value field instead of replacing it')
-    .action(async (nodeId: string, fieldName: string, value: string, options: { fieldId?: string; optionId?: string; append?: boolean }) => {
+    .action(async (nodeId: string, fieldName: string, value: string | undefined, options: { fieldId?: string; optionId?: string; append?: boolean }) => {
       try {
         const backend = await resolveBackend();
         if (!backend.supportsMutations()) {
@@ -37,6 +37,11 @@ export function createSetFieldCommand(): Command {
           console.log(`  Field: ${result.attributeId}`);
           console.log(`  Option: ${result.optionName}`);
         } else {
+          if (value === undefined) {
+            console.error('Error: Field value is required unless --option-id is used.');
+            process.exit(1);
+          }
+
           // Content field (text, number, date, url, email)
           const result = await backend.setFieldContent(nodeId, attributeId, value, mode);
           console.log(`${mode === 'append' ? 'Appended to field on' : 'Set field on'} node ${result.nodeId}`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -197,7 +197,7 @@ program.addCommand(createRecentCommand());     // supertag recent --period 24h -
 // F-094: Local API mutation commands
 program.addCommand(createEditCommand());       // supertag edit <nodeId> --name --description
 program.addCommand(createTagCommand());        // supertag tag add|remove|create
-program.addCommand(createSetFieldCommand());   // supertag set-field <nodeId> <field> <value>
+program.addCommand(createSetFieldCommand());   // supertag set-field <nodeId> <field> <value> [--append]
 program.addCommand(createTrashCommand());      // supertag trash <nodeId>
 program.addCommand(createDoneCommand());       // supertag done <nodeId>
 program.addCommand(createUndoneCommand());     // supertag undone <nodeId>

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -322,13 +322,13 @@ const allTools = [
       {
         name: 'tana_set_field',
         description:
-          'Set a text field value on a node. Requires Local API.',
+          'Set or append a text field value on a node. Use mode="append" for multi-value fields. Requires Local API.',
         inputSchema: schemas.zodToJsonSchema(schemas.setFieldSchema),
       },
       {
         name: 'tana_set_field_option',
         description:
-          'Set a field option (dropdown/select value) on a node. Requires Local API.',
+          'Set or append a field option (dropdown/select value) on a node. Use mode="append" for multi-value option fields. Requires Local API.',
         inputSchema: schemas.zodToJsonSchema(schemas.setFieldOptionSchema),
       },
       {

--- a/src/mcp/schemas.ts
+++ b/src/mcp/schemas.ts
@@ -831,6 +831,7 @@ export const setFieldSchema = z.object({
   nodeId: z.string().min(1).describe('Tana node ID to set field on'),
   attributeId: z.string().min(1).describe('Field attribute ID'),
   content: z.string().describe('Field value content'),
+  mode: z.enum(['replace', 'append']).default('replace').describe('Replace the field value or append to a multi-value field'),
 });
 export type SetFieldInput = z.infer<typeof setFieldSchema>;
 
@@ -839,6 +840,7 @@ export const setFieldOptionSchema = z.object({
   nodeId: z.string().min(1).describe('Tana node ID to set field option on'),
   attributeId: z.string().min(1).describe('Field attribute ID'),
   optionId: z.string().min(1).describe('Option ID to set'),
+  mode: z.enum(['replace', 'append']).default('replace').describe('Replace the selected option or append to a multi-value option field'),
 });
 export type SetFieldOptionInput = z.infer<typeof setFieldOptionSchema>;
 

--- a/src/mcp/tool-registry.ts
+++ b/src/mcp/tool-registry.ts
@@ -249,15 +249,15 @@ export const TOOL_METADATA: ToolMetadata[] = [
   },
   {
     name: 'tana_set_field',
-    description: 'Set a field value on a node',
+    description: 'Set or append a field value on a node',
     category: 'mutate',
-    example: 'Set Status field to "Done"',
+    example: 'Append a note to a multi-value field',
   },
   {
     name: 'tana_set_field_option',
-    description: 'Set a field option (dropdown) on a node',
+    description: 'Set or append a field option (dropdown) on a node',
     category: 'mutate',
-    example: 'Set Priority to a specific option',
+    example: 'Append an option to a multi-value field',
   },
   {
     name: 'tana_trash_node',

--- a/src/mcp/tools/set-field.ts
+++ b/src/mcp/tools/set-field.ts
@@ -10,6 +10,7 @@ export async function handleSetField(args: {
   nodeId: string;
   attributeId: string;
   content: string;
+  mode?: 'replace' | 'append';
 }) {
   try {
     const backend = await resolveBackend();
@@ -20,9 +21,10 @@ export async function handleSetField(args: {
       };
     }
 
-    const result = await backend.setFieldContent(args.nodeId, args.attributeId, args.content);
+    const mode = args.mode ?? 'replace';
+    const result = await backend.setFieldContent(args.nodeId, args.attributeId, args.content, mode);
     return {
-      content: [{ type: 'text' as const, text: `Set field ${result.attributeId} on node ${result.nodeId}: ${result.content}` }],
+      content: [{ type: 'text' as const, text: `${mode === 'append' ? 'Appended to' : 'Set'} field ${result.attributeId} on node ${result.nodeId}: ${result.content}` }],
     };
   } catch (error) {
     return handleMcpError(error);
@@ -33,6 +35,7 @@ export async function handleSetFieldOption(args: {
   nodeId: string;
   attributeId: string;
   optionId: string;
+  mode?: 'replace' | 'append';
 }) {
   try {
     const backend = await resolveBackend();
@@ -43,9 +46,10 @@ export async function handleSetFieldOption(args: {
       };
     }
 
-    const result = await backend.setFieldOption(args.nodeId, args.attributeId, args.optionId);
+    const mode = args.mode ?? 'replace';
+    const result = await backend.setFieldOption(args.nodeId, args.attributeId, args.optionId, mode);
     return {
-      content: [{ type: 'text' as const, text: `Set option field ${result.attributeId} on node ${result.nodeId}: ${result.optionName}` }],
+      content: [{ type: 'text' as const, text: `${mode === 'append' ? 'Appended option to' : 'Set option field'} ${result.attributeId} on node ${result.nodeId}: ${result.optionName}` }],
     };
   } catch (error) {
     return handleMcpError(error);

--- a/src/types/local-api.ts
+++ b/src/types/local-api.ts
@@ -180,21 +180,26 @@ export type TagOperationResponse = z.infer<typeof TagOperationResponseSchema>;
 // Field Types
 // =============================================================================
 
+export const FieldSetModeSchema = z.enum(["replace", "append"]);
+export type FieldSetMode = z.infer<typeof FieldSetModeSchema>;
+
 export const FieldContentRequestSchema = z.object({
-  content: z.string(),
+  content: z.string().nullable(),
+  mode: FieldSetModeSchema.optional(),
 });
 export type FieldContentRequest = z.infer<typeof FieldContentRequestSchema>;
 
 export const FieldContentResponseSchema = z.object({
   nodeId: z.string(),
   attributeId: z.string(),
-  content: z.string(),
+  content: z.string().nullable(),
   message: z.string(),
 });
 export type FieldContentResponse = z.infer<typeof FieldContentResponseSchema>;
 
 export const FieldOptionRequestSchema = z.object({
   optionId: z.string(),
+  mode: FieldSetModeSchema.optional(),
 });
 export type FieldOptionRequest = z.infer<typeof FieldOptionRequestSchema>;
 

--- a/tests/integration/local-api-integration.test.ts
+++ b/tests/integration/local-api-integration.test.ts
@@ -359,6 +359,40 @@ describe("F-094: Local API Integration", () => {
         content: "hello",
       });
       expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.mode).toBe("replace");
+      }
+
+      const append = setFieldSchema.safeParse({
+        nodeId: "n1",
+        attributeId: "attr1",
+        content: "hello",
+        mode: "append",
+      });
+      expect(append.success).toBe(true);
+
+      const invalid = setFieldSchema.safeParse({
+        nodeId: "n1",
+        attributeId: "attr1",
+        content: "hello",
+        mode: "merge",
+      });
+      expect(invalid.success).toBe(false);
+    });
+
+    it("should validate setFieldOptionSchema append mode correctly", async () => {
+      const { setFieldOptionSchema } = await import("../../src/mcp/schemas");
+
+      const result = setFieldOptionSchema.safeParse({
+        nodeId: "n1",
+        attributeId: "attr1",
+        optionId: "opt1",
+        mode: "append",
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.mode).toBe("append");
+      }
     });
 
     it("should validate trashNodeSchema correctly", async () => {
@@ -536,6 +570,7 @@ describe("F-094: Local API Integration", () => {
       expect(result).toContain("set-field");
       expect(result).toContain("nodeId");
       expect(result).toContain("fieldName");
+      expect(result).toContain("--append");
     }, CLI_TIMEOUT);
 
     it("should register trash command", async () => {

--- a/tests/integration/local-api-integration.test.ts
+++ b/tests/integration/local-api-integration.test.ts
@@ -570,6 +570,7 @@ describe("F-094: Local API Integration", () => {
       expect(result).toContain("set-field");
       expect(result).toContain("nodeId");
       expect(result).toContain("fieldName");
+      expect(result).toContain("[value]");
       expect(result).toContain("--append");
     }, CLI_TIMEOUT);
 


### PR DESCRIPTION
## Summary

- expose Tana Local API `mode: "append"` for text/content field updates
- expose the same append mode for option-field updates on multi-value fields
- update CLI, MCP schemas/handlers, backend/client types, docs, and focused tests

## OpenAPI Evidence

Observed locally on 2026-06-22 with:

`rtk bun -e "const spec=await fetch('http://localhost:8262/openapi.json').then(r=>r.json()); ..."`

The OpenAPI document reports:

- `openapi`: `3.1.1`
- `info.title`: `Tana Local API`
- `info.version`: `1.0.0`

Relevant request-body schemas:

```json
{
  "path": "/nodes/{nodeId}/fields/{attributeId}/content",
  "properties": {
    "content": {
      "anyOf": [{ "type": "string" }, { "type": "null" }],
      "description": "The string value to set (null to clear the field)"
    },
    "mode": {
      "enum": ["replace", "append"],
      "default": "replace",
      "description": "Whether to replace the existing value or append to it (for multi-value fields)"
    }
  },
  "required": ["content"]
}
```

```json
{
  "path": "/nodes/{nodeId}/fields/{attributeId}/option",
  "properties": {
    "optionId": {
      "type": "string",
      "description": "The node id of the option value to set"
    },
    "mode": {
      "enum": ["replace", "append"],
      "default": "replace",
      "description": "Whether to replace the existing value or append to it (for multi-value fields)"
    }
  },
  "required": ["optionId"]
}
```

The option endpoint schema is singular (`optionId`, not `optionIds`), so appending several option values means making one append call per option.

## Verification

- `rtk bunx tsc --noEmit`
- `rtk bun test tests/integration/local-api-integration.test.ts src/mcp/tools/__tests__/tool-schema.test.ts tests/unit/tool-mode.test.ts tests/unit/mcp-tool-mode-integration.test.ts`
